### PR TITLE
Add api support for people/:id address, postcode, and badge_text

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -202,7 +202,8 @@ uses `_` for single-character wildcards and `%` for multiple characters.
 ### `POST people`
 - Requires authentication and `member_admin` authority
 - Parameters: `membership`, `legal_name`, `email`, `public_first_name`,
-  `public_last_name`, `city`, `state`, `country`, `paper_pubs`
+  `public_last_name`, `city`, `state`, `country`, `paper_pubs`,
+  `postcode`, `address`, `badge_text`
 
 Add new person. If `membership` is not `'NonMember'`, a new `member_number` will
 be generated.
@@ -228,6 +229,7 @@ data, `member_admin` or `member_list` authority is required.
 {
   id, last_modified, member_number, membership, legal_name, email,
   public_first_name, public_last_name, city, state, country,
+  postcode, address, badge_text,
   can_hugo_nominate, can_hugo_vote, can_site_select,
   paper_pubs: { name, address, country },
   preferred_name, daypass, daypass_days
@@ -254,7 +256,7 @@ match the session data, `member_admin` or `member_list` authority is required.
 - Requires authentication
 - Parameters: `membership` (`member_admin` only), `email` (`member_admin` only),
   `legal_name`, `public_first_name`, `public_last_name`, `city`, `state`,
-  `country`, `paper_pubs`
+  `country`, `postcode`, `address`, `badge_text`, `paper_pubs`
 
 Update the data for the person matching `id`. If its email address does not
 match the session data, `member_admin` authority is required.

--- a/members/app.js
+++ b/members/app.js
@@ -58,7 +58,7 @@ router.get('/purchase/keys', purchase.getStripeKeys);
 router.get('/purchase/list', purchase.getPurchases);
 router.post('/purchase/other', purchase.makeOtherPurchase);
 router.get('/purchase/prices', purchase.getPrices);
-router.post('/webhook/stripe', purchase.handleStripeWebhook)
+router.post('/webhook/stripe', purchase.handleStripeWebhook);
 
 // subsequent routes require authentication
 router.use(user.authenticate);
@@ -132,7 +132,7 @@ app.use((req, res, next) => {
 const isDevEnv = (app.get('env') === 'development');
 app.use((err, req, res, next) => {
   const error = err.error || err;
-  debugErrors(error instanceof Error ? error.message : err)
+  debugErrors(error instanceof Error ? error.message : err);
   const data = { status: 'error', message: error.message };
   if (isDevEnv) data.error = err;
   const status = err.status || error.status || error.name == 'InputError' && 400 || 500;

--- a/members/lib/people.js
+++ b/members/lib/people.js
@@ -1,12 +1,12 @@
 const { setKeyChecked } = require('./key');
 const { AuthError, InputError } = require('./errors');
-const { mailTask, updateMailRecipient } = require('./mail')
+const { mailTask, updateMailRecipient } = require('./mail');
 const LogEntry = require('./types/logentry');
 const Person = require('./types/person');
 
 const selectAllPeopleData = `
   SELECT p.*, preferred_name(p), d.status AS daypass, daypass_days(d)
-    FROM people p LEFT JOIN daypasses d ON (p.id = d.person_id)`
+    FROM people p LEFT JOIN daypasses d ON (p.id = d.person_id)`;
 
 module.exports = {
   selectAllPeopleData,
@@ -116,11 +116,11 @@ function getPerson(req, res, next) {
 }
 
 function addPerson(req, db, person) {
-  const passDays = person.passDays
-  const status = person.data.membership
+  const passDays = person.passDays;
+  const status = person.data.membership;
   if (passDays.length) {
-    person.data.membership = 'NonMember'
-    person.data.member_number = null
+    person.data.membership = 'NonMember';
+    person.data.member_number = null;
   }
   const log = new LogEntry(req, 'Add new person');
   let res;
@@ -131,20 +131,20 @@ function addPerson(req, db, person) {
       return tx.one(`INSERT INTO People ${person.sqlValues} RETURNING id, member_number`, person.data);
 
     case 1:
-      person.data.id = data.id
-      person.data.member_number = data.member_number
+      person.data.id = data.id;
+      person.data.member_number = data.member_number;
       res = data;
-      log.subject = data.id
-      return tx.none(`INSERT INTO Log ${log.sqlValues}`, log)
+      log.subject = data.id;
+      return tx.none(`INSERT INTO Log ${log.sqlValues}`, log);
 
     case 2:
       if (passDays.length) {
-        person.data.membership = status
-        const trueDays = passDays.map(d => 'true').join(',')
+        person.data.membership = status;
+        const trueDays = passDays.map(d => 'true').join(',');
         return tx.none(`
           INSERT INTO daypasses (person_id,status,${passDays.join(',')})
                VALUES ($(id),$(membership),${trueDays})`, person.data
-        )
+        );
       }
 
   }}))
@@ -200,7 +200,7 @@ function updatePerson(req, res, next) {
   ]))
     .then(([{ can_hugo_nominate, can_hugo_vote, next_email, prev_email, name }, key]) => {
       email = next_email;
-      if (next_email === prev_email) return {}
+      if (next_email === prev_email) return {};
       updateMailRecipient(db, prev_email);
       return !can_hugo_nominate && !can_hugo_vote ? {}
         : key ? { key: key.key, name }

--- a/members/lib/types/person.js
+++ b/members/lib/types/person.js
@@ -23,7 +23,7 @@ class Person {
   }
 
   static hugoVoterType(membership) {
-    return [ 'Supporter', 'YoungAdult', 'FirstWorldcon', 'Adult' ].indexOf(membership) !== -1
+    return [ 'Supporter', 'YoungAdult', 'FirstWorldcon', 'Adult' ].indexOf(membership) !== -1;
   }
 
   static get userModFields() {
@@ -64,11 +64,11 @@ class Person {
   }
 
   get hugoVoterType() {
-    return Person.hugoVoterType(this.data.membership)
+    return Person.hugoVoterType(this.data.membership);
   }
 
   get passDays() {
-    return Object.keys(this.data).filter(key => /^day\d+$/.test(key) && this.data[key])
+    return Object.keys(this.data).filter(key => /^day\d+$/.test(key) && this.data[key]);
   }
 
   get preferredName() {
@@ -77,10 +77,10 @@ class Person {
   }
 
   get priceAsNewMember() {
-    const ms = prices.memberships[this.data.membership]
-    const pp = this.data.paper_pubs ? prices.PaperPubs.amount : 0
-    const da = this.data.discount ? this.data.discount.amount : 0
-    return (ms && ms.amount || 0) + pp - da
+    const ms = prices.memberships[this.data.membership];
+    const pp = this.data.paper_pubs ? prices.PaperPubs.amount : 0;
+    const da = this.data.discount ? this.data.discount.amount : 0;
+    return (ms && ms.amount || 0) + pp - da;
   }
 
   get sqlValues() {

--- a/members/lib/types/person.js
+++ b/members/lib/types/person.js
@@ -12,6 +12,7 @@ class Person {
       'public_first_name', 'public_last_name',  // text
       'email',  // text
       'city', 'state', 'country',  // text
+      'postcode', 'address',  // text
       'badge_text',  // text
       'can_hugo_nominate', 'can_hugo_vote', 'can_site_select',  // bool NOT NULL DEFAULT false
       'paper_pubs'  // jsonb
@@ -27,7 +28,18 @@ class Person {
   }
 
   static get userModFields() {
-    return [ 'legal_name', 'public_first_name', 'public_last_name', 'city', 'state', 'country', 'paper_pubs' ];
+    return [
+      'legal_name',
+      'public_first_name',
+      'public_last_name',
+      'city',
+      'state',
+      'country',
+      'postcode',
+      'address',
+      'badge_text',
+      'paper_pubs'
+    ];
   }
 
   static get membershipTypes() {

--- a/members/static/purchase-data.json
+++ b/members/static/purchase-data.json
@@ -71,6 +71,18 @@
       "country": {
         "label": "Country",
         "type": "string"
+      },
+      "postcode": {
+        "label": "Postal Code",
+        "type": "string"
+      },
+      "address": {
+        "label": "Address",
+        "type": "string"
+      },
+      "badge_text": {
+        "label": "Badge Name",
+        "type": "string"
       }
     },
     "types": [
@@ -124,6 +136,18 @@
       },
       "country": {
         "label": "Country",
+        "type": "string"
+      },
+      "postcode": {
+        "label": "Postal Code",
+        "type": "string"
+      },
+      "address": {
+        "label": "Address",
+        "type": "string"
+      },
+      "badge_text": {
+        "label": "Badge Name",
         "type": "string"
       },
       "paper_pubs": {

--- a/postgres/init/20-kansa-init.sql
+++ b/postgres/init/20-kansa-init.sql
@@ -25,6 +25,8 @@ CREATE TABLE IF NOT EXISTS People (
     city text,
     state text,
     country text,
+    postcode text,
+    address text,
     badge_text text,
     can_hugo_nominate bool NOT NULL DEFAULT false,
     can_hugo_vote bool NOT NULL DEFAULT false,

--- a/tools/kansa-importer/fake-data/members.csv
+++ b/tools/kansa-importer/fake-data/members.csv
@@ -1,648 +1,648 @@
-legal_name,supporter,supporter_date,upgrade,upgrade_date,email,city,state,country,public_first_name,public_last_name,paper_pubs_id
-Samuel Vimes,Supporter,8/4/2016 12:29:02,,,s.vimes@gmial.ocm,Ankh-Morpork,,The Disc,,,1
-Factual Blob,,,First Worldcon,8/4/2016 12:30:50,fblog@fblobsblog.com,Fact City,Data Central,Blobitania,Fake (Factual),Blob,
-Æthelwine B. Clobberfeld,,,First Worldcon,8/4/2016 12:31:26,abc@cba.nr,Yaren,Yaren District,Nauru,Æthelwine,Clobberfeld,2
-Polly Amorous,,,Adult,8/4/2016 12:31:37,Allthelove@manymoresomuch.fi,Helsinki,Helsinki,Finland,Polly,Amorous,3
-Jorma Mörönen,,,Adult,8/4/2016 12:32:25,jorma@moronen.com,Paris,,France,,,
-Lost At Void,,,First Worldcon,8/4/2016 12:32:42,lost@void.net,Emerald City,,,Lost,Void,
-Hoy Ping Pong,,,Adult,8/4/2016 12:33:11,hpp@tucker.net,Bloomington,IL,USA,Hoy Ping,Pong,
-Rodrigo Almodovar,,,Adult,8/4/2016 12:34:32,Ralmo@mwahaha.boo,Acapulco,Mexico,Mexico,Roro,Almi,4
-Dr. Ackula,,,Adult,8/4/2016 12:34:52,Forrest@ackerman.per,Hollywood,CA,USA,Dr.,Ackula,5
-TreeFree Forest Sprite,Supporter,8/4/2016 12:35:21,,,SaplingPower@enddeforestationnow.net,Orick,California,United State,TreeFree,Forest Sprite,
-Donald Duck,,,Adult,8/4/2016 12:36:33,donald@duck.duck,Duckburg,Calisota,,Donald,Duck,
-Thomas Fool,,,First Worldcon,8/4/2016 12:37:13,thomas.fool@hell.gov,Houska,,Hell,Thomas,Fool,
-Jaakko Parantainen,,,First Worldcon,8/4/2016 12:39:52,jaakkoparantainenkummelista@gmail.com,Tampesteri,Hervanta,Finland,Jaakko,Parantainen,
-Pongo,,,Youth,8/4/2016 12:41:30,pingo@pongo.tv,Dublin,Dublin,Ireland,P,Ongo,6
-Donald Trump,,,Adult,8/4/2016 12:43:42,donald@trump.com,Twitsville,Illinois,The GOOD OL' USA,Donald,Trump,7
-Lempi Lempinen ,,,First Worldcon,8/4/2016 12:45:00,fakefake@email.com,Lovevillage ,,Amoria,,,
-Dennis Mitchell,,,Child,8/4/2016 12:45:49,youllnevercatchmemrwilson@troublemakerheartbreaker.net,Cape Canaveral,Florida,USA,Dennis,the Menace,
-Gandalf the Grey,,,First Worldcon,8/4/2016 12:46:20,gandalf@greyhavens.elf,Shire,,Middle-Earth,Gandalf,the Grey,8
-Mr. Bigbang oohlala,,,Child,8/4/2016 12:47:09,,,,,,,
-Fan McFanface,,,Adult,8/4/2016 12:47:16,mcfanface@gmail.com,Helsinki,,Finland,,,
-Sauron,Supporter,8/4/2016 12:47:23,,,sauron@mordor.com,Mordor,,,,,9
-Fergus Crowley,,,Adult,8/4/2016 12:47:39,fergus@hades.dot.au,Dis,Hades,HELL,Fergus,Crowley,
-T.H.E. End,,,Adult,8/4/2016 12:48:08,1 Deadend Road,Terminus,Final,Nulla,Ted,End,10
-Hermione Targaryen,,,First Worldcon,8/4/2016 12:49:38,harryswife@dragonstone.wes,Meereen,Hogwarts,Slaver's Bay,Hermione,Targaryen,
-Acidia Raine ,,,Youth,8/4/2016 12:49:40,moreacid@fakemail.concon,Gotham,,,,,11
-toru loru,,,First Worldcon,8/4/2016 12:51:00,totulotu@aaa.ee,soomaa,jaani,eesti,totu,lotu,12
-Irma-Perttuli Lampipuhurinen ,,,Child,8/4/2016 12:51:19,irma@perttuli.net,,,finland,irmaperttuli ,,
-Patrick Jane,,,Adult,8/4/2016 12:52:10,patrick.jane@cbi.gov,Sacramento,California,USA,Patrick,Jane,
-Alan Foster,,,First Worldcon,8/4/2016 12:52:46,alanfff@iki.fi,Sydney,NSW,Australia,Alan,Foster,13
-Nasty Butthole,,,First Worldcon,8/4/2016 12:52:59,nasty@butthole.gov,Poopadelphia,Hineyland,Glutania Maximania,Bootylicious,Poopshoot,14
-"Isaura ""the Cat"" astin Eraday",,,Kid-in-tow,8/4/2016 12:54:57,isaura@fakemail.eu,Valdis,,Valdyas,Isa,(none),
-Kooky Doodlehead,,,Kid-in-tow,8/4/2016 12:55:46,whackadoodle@moonpie.com,Goola,Ming,Republic of Dunkybones,Kooky,Doodlehead,
-Bucky Barnes,,,Adult,8/4/2016 12:56:18,buckybarnes@captainamerica.com,New York,,USA,Bucky,Barnes,
-Daenerys Stormborn,,,Adult,8/4/2016 12:56:30,daenerys@queenodtheandals.com,King's landing,Westeros,Westeros,Mother of,Dragons,15
-Meriadoc Brandybuck II,Supporter,8/4/2016 12:56:51,,,merry@shire.org,Hobbiton,The Shire,Eriador,Merry,Brandybuck,16
-Tara Abernathy,,,First Worldcon,8/4/2016 12:57:27,tara@koseverburning.com,Alt Coulomb,Northern Gleb,,,,
-Alysei Athal astin Velain,,,Adult,8/4/2016 12:57:58,king@palace.vl,Valdis,,Valdyas,Athal,Velain,
-Mariel Hill,,,First Worldcon,8/4/2016 12:58:41,email@marielhill.com,Galway,Galway,Ireland,Mariel,Hill,17
-Sam Wilson,Supporter,8/4/2016 12:58:52,,,Falcon@Avengers.com,Washington DC,Washington DC,USA,Falcon,,
-Pullervo Saimaalta,,,Adult,8/4/2016 12:58:53,pullervo@saimaa,Pitkulajärvi,Saimaa,,,,18
-Drizzt Do'Urden,,,First Worldcon,8/4/2016 12:59:44,zakismyfather@menzoberranzan.com,Menzoberranzan,,,,,19
-Legolas Greenleaf,,,Adult,8/4/2016 13:00:42, ,,,Greenwood the Great,,,
-💩💩💩💩💩,Supporter,8/4/2016 13:01:10,,,com+@com@com.com,💩,💩,💩,,,
-Kamala Khan,,,Youth,8/4/2016 13:01:14,,Albany,NY,USA,Ms,Marvel,20
-Esko Mörkö,,,First Worldcon,8/4/2016 13:01:22,esko.morko@morko.tv,Ankkalinna,Hoth,Gondor,Esko,Mörkö,
-Möhmötti Puupparanta,,,Adult,8/4/2016 13:01:28,möhmötti.puupparanta@gmail.com,Tampere,Pirkanmaa,Finland,Möhmötti,Puupparanta,
-Paddington Bear,,,Adult,8/4/2016 13:01:54,padington@teddy.com,Lima,,Peru,Paddy,Bear,21
-Trogdor,,,First Worldcon,8/4/2016 13:01:56,Burninator@gmail.com,Cave,The country side,Internet,Trogdor,la Burninator,
-Steve Great,,,First Worldcon,8/4/2016 13:02:19,greatgreatsteve@fakemail.com,Dublin,,Ireland,Steve,Great,
-M.R. Universe,,,Adult,8/4/2016 13:03:16,iamme@mruniverse.ego,Presses,Pushes,Abs,Me,Universe,
-Katniss Rogers,,,First Worldcon,8/4/2016 13:04:31,mockingjay@avengers.org,n/a,District 12,Panem,Mockingjay,Rogers,22
-Siipiratas Ankka,Supporter,8/4/2016 13:04:46,,,siipiratas@gmail.com,Siippari,Piippari,Veikkonen,Siipiratas,Ankka,
-Mogens Ångström,,,First Worldcon,8/4/2016 13:04:54,mogens@angstrom.fi,Kauniainen,,Finland,Mogens,Ångström,
-Scarlet Witch,,,Adult,8/4/2016 13:04:56,avengers.scarlet.witch@earths.mightiest.net,New York,New York,USA,Wanda,Maximoff,23
-Carol Ní Chonghaile,Supporter,8/4/2016 13:05:06,,,myfakename@yahoo.com,Dublin,Dublin,Rep. of Ireland,CarolC,,
-Laalaa Land,,,Youth,8/4/2016 13:05:31,laalaalandiassaollaan@suomi24.fi,Laiska,Luiska,Land,Laalaa,Land,
-Opun Undo,,,First Worldcon,8/4/2016 13:07:28,rubber@eraser.net,Dodge Town,Iowa,USA,Nualla,Blank,
-Pantsy McPants,,,First Worldcon,8/4/2016 13:07:54,antsypantsy+fake@hotmail.com,Stockholm,,SWEDEN,Pantsy,McPants,
-Maija Mehilainen,,,First Worldcon,8/4/2016 13:08:21,maija@mehilainen.com,Bee Hive City,Bee province,Bee country,Maija,Mehilainen,24
-Mary Poppins,,,First Worldcon,8/4/2016 13:08:24,aaargh.nnghh@eww.com,Helsinki,,Finland,Just,Me,
-WYMAN MANDERLY,Supporter,8/4/2016 13:10:35,,,wayman@whiteharbor.wes,White Harbor,The North,Westeros,WAYMAN ,THE PIEMAN,
-Maria Siirala,Supporter,8/4/2016 13:11:20,,,nowhere@nope.not,Atlantis,Gallifrey,The moon,,,
-Donna Noble,,,Adult,8/4/2016 13:12:15,besttempever@chiswick.co.uk,Chiswick,London,UK,Donna,Noble,
-Melissa Entwhistle,,,First Worldcon,8/4/2016 13:13:24,huzzah@huzzahagain.com,Serendipity,Mastodon,Floramonde,Micro,Fashion,25
-Quicksilver Girl,,,Adult,8/4/2016 13:13:40,qsg@email.com,Starry Night,,,,,
-Amelia Pond,,,Kid-in-tow,8/4/2016 13:14:07,amyandrory@theponds.com,Leadworth,England,UK,Amy,Pond Williams,
-Spendle Backreach,,,Adult,8/4/2016 13:14:23,spendle@aol.noseriously.co.uk,Chang Rai,,Thailand,Spendle,Backreach,26
-Yippieh Ayeih,,,Adult,8/4/2016 13:14:28,Yippiehayeih@gmail.com,Buxtehude,,Germany,Yippieh,Ayeih,
-SELECT count(*) from *.*;,,,Child,8/4/2016 13:14:35,not@real.com,Mallicious,United States,Awkward,Obviously silly test. :) ,Nope,
-Rose Tyler,,,Youth,8/4/2016 13:15:12,rose@otherdimension.org,London,London,UK,Rose,Tyler,
-Jack T. Ladd,,,First Worldcon,8/4/2016 13:16:15,Jackyboy@pan.net,,,,,,27
-Yappa Dappadoo,,,First Worldcon,8/4/2016 13:16:39,Yappadappadoo@hotmail.com,London,,Great Britain,Yappa,Dappadoo,28
-I saw a cake from a distance,Supporter,8/4/2016 13:16:50,,,distance@cake.i.saw,Cakedistant,Isaw,Atadistance,Isawacake,Atadistance,
-Rory Williams,,,Kid-in-tow,8/4/2016 13:17:06,amyandrory@theponds.com,Leadworth,England,UK,Rory,Williams,
-It was a chcocolate cake I think,,,First Worldcon,8/4/2016 13:17:59,itwas@chocolate.cake,Ithink,Distance,Cake,Itwaschcoclate,Ithink,
-Holy Moly,Supporter,8/4/2016 13:18:07,,,Holymoly@yahoo.com,Rome,,Italy,Holy,Moly,29
-Martha Jones,,,First Worldcon,8/4/2016 13:18:38,ilovethedoctor@marthajones.co.uk,London,London,UK,Martha,Jones,
-So I ran quickly towards it,,,Youth,8/4/2016 13:19:05,SoI@ran.quickly.mo,Towards,It,Ranqucik,Soiranquickly,Towardsit,
-But it was just my imagination playing tricks,,,Youth,8/4/2016 13:20:09,itwas@just.my,Imagination,Playing,Tricks,Itwasjustmy,Imagination-Playingtricks,
-Blaargh,,,First Worldcon,8/4/2016 13:21:03,Duh@somewhere.com,HereOrThere,Nope,That One,Tiff,Ehrm,30
-Oswin Oswald,Supporter,8/4/2016 13:21:29,,,suffle@dalek.com,Alaska,Dalek Asylum,Skaro,Oswin,Oswald,
-The New Robert Heinlein,,,Adult,8/4/2016 13:22:09,robert@heinlein.moon,Robert,Heinlein,Moon,New Robert,heinlein,
-Jophan van Boi,,,Adult,8/4/2016 13:22:52,babbhdlorn_78@gmail.com,Minas Tirith,Gondor,Middle-earth,Jophan,the Great,31
-Domenic Jordan,,,First Worldcon,8/4/2016 13:23:03,domenic@jordan.com ,Alestra,Alestra,Alestra,Domenic,Jordan,32
-Hugo McHugoface,,,Adult,8/4/2016 13:23:18,hugo@mchugofa.ce,Hug,Omch,Ugoface,Hugo,McHugoface,
-Why Did the Chicken Cross The Road,Supporter,8/4/2016 13:24:28,,,whydid@thechicken.cro,The Road,Whydid,Australia,Whydidthechicken,Crosstheroad,
-Kate Aldridge ,,,First Worldcon,8/4/2016 13:26:58,elianara@mansion.com,New York City ,New York ,United States ,Kate ,Aldridge ,33
-Clara Oswald,,,Adult,8/4/2016 13:27:29,clara@stolentardis.uni,Blackpool,Lancashire,UK,Clara,Oswald,
-Jack Harkness,,,Adult,8/4/2016 13:29:08,captain@handsome.com,Awesome,Boeshane Peninsula,USA,Captain Jack,Harkness,
-Brune Keare,,,Adult,8/4/2016 13:30:08,krzyczacy@shanvaola.com,Shan Vaola,Zatoka snów,Shan Vaola ,Krzyczący w ciemności ,,
- Bruce Wayne,,,First Worldcon,8/4/2016 13:33:05,bruce@batman.bat,Gotham City,,United States,Bat,Man,
-Chris Yannic,Supporter,8/4/2016 13:35:22,,,chyann@ucdavis.edu,Davis,California,United States,,,
-Adam Mitchell,,,Youth,8/4/2016 13:35:47,hacker@vanstatten.com,Can't remember,England,UK,Adam,Mitchell,
-Mickey Smith,Supporter,8/4/2016 13:36:46,,,mickeytheidiot@rickey.com,London,England,UK,Mickey,Smith,
-Smurfette,,,Kid-in-tow,8/4/2016 13:37:15,smurfette@smurftown.sm,Smurftown,Blue Woods,Great Waterland,Smurfette,Smurf,34
-Astrid Peth,Supporter,8/4/2016 13:38:05,,,astrid@titanic.uni,Sto,Sto,Sto,Astrid,Peth,
-M. Galbois,,,First Worldcon,8/4/2016 13:38:10,galbois@galbois.com,Luxembourg,Luxembourg,Luxembourg,Stephane,Galb,35
-Felis Undomesticus,,,Adult,8/4/2016 13:38:25,cattish@gmail.com,Catopolis,Catnagar,Kuching,Kuching ,Hitam,36
-Sarah Jane Smith,,,Adult,8/4/2016 13:39:23,sarahjane@unit.co.uk,Foxgrove,England,UK,Sarah Jane,Smith,
-Mistress of the Wooden Spoon,,,First Worldcon,8/4/2016 13:39:54,spoonsrus@yippee.com,Spoonville,Oucharama,Kink Nation,Mistress,of the Wooden Spoon,
-Elizabetha von Finn,,,First Worldcon,8/4/2016 13:39:58,elizabetha.vonfinn@fakeemail.fake,Jäniksenselkä,Keski-Suomi,Finland,Elza,von Finn,
-Wilfred Mott,Supporter,8/4/2016 13:40:27,,,wilf@noble.com,Chiswick,London,UK,Wilfred,Mott,
-Mother of Dragons,,,First Worldcon,8/4/2016 13:40:50,Motherofdragons@fantasy.com,Meereen,Essos,Westeros,Daenerys,Targaryen,
-Leonardo da Vinci,,,Kid-in-tow,8/4/2016 13:41:13,Leonardo.is.the.greatest@genius.com,Da Vinci,,Italia!,Leo,DaV,37
-Evelyn Craven,,,Youth,8/4/2016 13:42:49,EvelynCraven@evelyncraven.com,London,London,UK,Evelyn,Craven,38
-Noodledipoodle,,,Kid-in-tow,8/4/2016 13:43:24,Noodles.poodles@com,Spaghetti Town,Lasagnia,Pasta Heaven,Maccaroni,Cheese,
-Kasa Obake,Supporter,8/4/2016 13:43:54,,,Fake@Email.com,Not,My,Real Address,Kasa,Obake,
-Vilunki-Petteri,,,First Worldcon,8/4/2016 13:43:59,vilunki-petteri@nope.com,Turku,,Finland,Vilunki-Petteri,Kusettaja,39
-Melody Pond,,,Child,8/4/2016 13:45:51,melody@pond.com,Demons Run,Demons Run,Demons Run,Melody,Pond,
-Vox Day,,,Child,8/4/2016 13:46:01,vox@day.com,Rome,,Italy,Teddy,Beale,40
-River Song,,,Adult,8/4/2016 13:46:39,river@badass.com,Leadworth,England,Great Britain,Doctor River,Song,
-Strawberry Sundae,,,Youth,8/4/2016 13:46:44,Strawberry-icecream@heaven.com,Icecreamparlor,Vanilla,Gelato,Lady,Berry,
-Happy Bladder,,,First Worldcon,8/4/2016 13:47:15,Happydotcom@com.com,Bubbling pub,,Pen Island,Happy,Bag,
-Craig Owens,,,Kid-in-tow,8/4/2016 13:47:44,craig@stormageddon.co.uk,Colchester,England,UK,Craig,Owens,
-Dr. Victor Von Doom,Supporter,8/4/2016 13:48:00,,,Dr.Doom@doom.com,Doomstad,,Latveria,Victor,Von Doom,
-Ada Celeritas,,,Adult,8/4/2016 13:49:21,Adaceleritas@arsmagica.com,Cad Gadu,Stonehenge Tribunal,Wales,Ada,Celeritas,41
-Alli Paasikivi,,,Youth,8/4/2016 13:53:56,a.paasik@meili.zxc.fin,Porvoo,,Åland,Alli,,
-미라,,,Youth,8/4/2016 13:54:38,mira@hanmail.net,서울,서울특별시,대한민국,미라,,
-Fakey McFakeface,,,First Worldcon,8/4/2016 13:55:18,mail@fakemail.com,Here,That place,There,,,
-Juho Kusti,,,First Worldcon,8/4/2016 13:56:24,,Turku,,Finlandia,,,42
-Throat Warbler Mangrove,,,First Worldcon,8/4/2016 13:58:12,NowWhatsAllThisThen@Hello.wot,Sweer Island,Gulf of Carpenteria,Australia,Raymond,Luxury-Yatch,43
-Мрако Беснишки,,,First Worldcon,8/4/2016 14:01:05,mb@nosuch.net,Knot ere,,EU,Мрако,,44
-Blue Jeep,,,Adult,8/4/2016 14:07:34,bluejeep61@mail.com,,,Oman,Blue,Jeep,
-Suska,,,First Worldcon,8/4/2016 14:07:56,,Lappeenranta,,Finland,,,45
-Irving Washington,,,Adult,8/4/2016 14:08:11,washington.irving@snorglebürg.ie,Snorglebürg,Bad-Snorglebürg,Irelland,Vashington,Irwing,46
-Lord Meow Meow,,,First Worldcon,8/4/2016 14:10:12,Fuzzyface@gmail.com,Purrington,Blarghles,Kittentopia,Bubbles,Meow Meow,
-Lord Tiberius Squee,,,First Worldcon,8/4/2016 14:11:12,tibbysquee@westeros.got,King's Landing,King's Landing,Westeros,Tiberius,Squee,47
-Jeanne-Elise de la Tourelle Fitou,,,Adult,8/4/2016 14:12:18,labellemarquise@mousquetaires.fr,Paris,Bretagne,Bretagne,Sylvan,None,
-Olivia Oil,,,Adult,8/4/2016 14:14:26,asdfasf@fge.de,Hamburg,Hamburg,Deutschland,Olli,Oil,48
-Rene d'Herblay,,,First Worldcon,8/4/2016 14:14:27,aramis@mousquetairs.fr,Paris,Les Vosges,La Belle France!,Aramis,,49
-Giant Panda,,,First Worldcon,8/4/2016 14:16:40,,Aachen,,Germany,Giant,Panda,
-Sally Warner,,,First Worldcon,8/4/2016 14:18:48,Sally.Warner@mail.com,Manchester,England,UK,Sally,Warner,
-Boxer Heelgood,,,Kid-in-tow,8/4/2016 14:19:17,makeawash@tawdry.tv,Humptulips,Washington,USA,Nancy,Drew,50
-Regina Phalange,,,First Worldcon,8/4/2016 14:20:17,you@yourmum,New York,Noo Yawk,South Korea,Princess Consuela,Banana-Hammock,
-Alec Ramsay,,,First Worldcon,8/4/2016 14:20:25,IlovetheBlack@stallion.com,New York,NY,USA,Alec,,51
-Zaphod Beeblebrox CXXIII,,,Kid-in-tow,8/4/2016 14:20:27,heart.of.gold@stolen.net,Galaxyville,The Universe,Space-Time Continuum,Ford,Prefect,
-Årån-Öän Ənndœ,,,First Worldcon,8/4/2016 14:21:07,what's it to you?,Sjır,N/A,Vinland,Årån-Öän,Ənndœ,52
-Creator of acorns,,,Kid-in-tow,8/4/2016 14:25:19,redoak@treefarm.org,Forrest City,Taiga,Mother Tree,Adolf,Acorn,53
-BunnyCat,,,Adult,8/4/2016 14:25:30,BunnyFromHell@gmail.com,Ytre Enebakk,Akershus,Norway,Bunny,Cat,
-Freda bloggs,,,Youth,8/4/2016 14:26:07,freda.bloggs@wherever.com,Brighton,Surrey,Belgium,Freda,Mindyourown,54
-Ørjan Gålbærg,,,Kid-in-tow,8/4/2016 14:26:28,Maybetoo@yes.no,Oslo,,Norway,Ørjan,Gålbærg,
-Inigo Montoya,,,Adult,8/4/2016 14:27:48,prepare@die.die.die,Capital City,Land of far away,dangerous,Inigo,Montoya,55
-Dirk Hardfist,,,First Worldcon,8/4/2016 14:28:08,david.cameron@oink.com,Reseune ,New Gehenna,Cyteen,Arianne,Emory,56
-SadPuppy2479,,,Child,8/4/2016 14:28:41,sadpuppy2479@hotmail.com,Fedoraville,The Vale of Man-Tears,USA,Saddest,Puppy,57
-Claude Deglar,,,First Worldcon,8/4/2016 14:30:09,Claude@ozarklovecamp.com,Muncie,IN,United States,Claude,Deglar,58
-DeerVölt,,,Kid-in-tow,8/4/2016 14:30:10,nakke@nakutta.ja,Helsinski,Juusimaa,Funland,Narsku,Lorsku,
-Bressica Tantalus,,,Adult,8/4/2016 14:32:20,btant@fabulous.tld,London,Kansas,Australia,Bress,,
-Loana Miriam,,,Kid-in-tow,8/4/2016 14:33:08,Qser@der.vn.com,Hcmc,N/A,Vietnam,Hoa,Nguyen,59
-Turhikki Möhnä-Kikkare,,,First Worldcon,8/4/2016 14:35:34,turhikki@geemail.con,Tiuskanpohja,Nälviä,Vuolangan vapaavaltio,Turhikki,Möhnä-Kikkare,60
-Roy Batty,,,Kid-in-tow,8/4/2016 14:37:03,doandroidsdreamofelectricsheep@tyrrell.biz,San Francisco,CA,Orion,Roy,Batty,61
-Herbert J Gruntfuttock,,,Adult,8/4/2016 14:37:14,hj@gruntfuttock.co.uk,London,,UK,John,Doe,62
-Glorious Falsity,,,Adult,8/4/2016 14:43:10,fake@fakeness.fake,Falcity,Fakeplace,Fakeness,Glory,TRUE,
-Helanius Bigglesworth,,,First Worldcon,8/4/2016 14:45:45,Bobama@whitehouse.gov,Intercourse,PA,Belize,Quinoa,Fromagiere,
-Gerbil Hubernough,Supporter,8/4/2016 14:50:17,,,gargle33.2guppmail.com,Fakevile,Ohio,USA,The Mighty Gerbil,,
-Tufflm Girdflump,,,Adult,8/4/2016 14:50:28,tgirdflump@gmail.com,Mumbai,Kenyatta,India,Tufflm,Girdflump,
-Lance Armstrong,,,First Worldcon,8/4/2016 14:50:41,lance@livestrong.org,Houston,Texas,USA,Lance,Armstrong,
-Email with Plus in it,,,Youth,8/4/2016 14:54:40,email+foo@example.com,,,,,,
-Mahlah Zelophehad Manasseh,,,Kid-in-tow,8/4/2016 15:05:22,emzy_manasseh@gotmail.com,Gilead,MA,USA,Emzy,Manasseh,63
-Arthur Dent,,,Adult,8/4/2016 15:06:19,Arthur.dent@bbc.co.uk,Cottington,Somerset,UK,Arthur,Dent,
-Kellosepän jalkavaimon käsväsky,,,Kid-in-tow,8/4/2016 15:10:47,Väskyläinen@citissä.nero,Kaapin takana naulakko,Ylin oksa,Kellosepän kellari,Neulottu,Tyylikäs-käsväsky,64
-Archer de Grundy Penny-Hassett,,,First Worldcon,8/4/2016 15:11:02,archer@penny-hassett.co.uk,Blairgowrie,Perthshire,United Kingdom,Archer,Penny-Hassett,
-Mentega Kuning,,,First Worldcon,8/4/2016 15:12:34,mentega.kuning@gmail.com,Lembu Town,Biri Valley,People's Republic of Padang,Mentega,Kuning,
-Jorma Ei-Aivan-Uotila,,,Adult,8/4/2016 15:13:35,jortsuboy69@hotmale.com,Melkein Helsinki,,Sumoi,Pertti,Peräpeikkola,65
-Firstname La Stname,,,First Worldcon,8/4/2016 15:16:49,FirstnameLaStname@nowh.ere,This Town,Rhode Island,USA,Firstname,,
-"O'Fish, Al",,,Kid-in-tow,8/4/2016 15:17:20,dsf<sdafkd<fhkas+dfhldfjsha@example.com,Paris,France,France,Al,O'Fish,
- 中国人,,,Adult,8/4/2016 15:21:19,zhong.guo.ren@outlook.com,Shanghai ,Pudong,People's Republicbod China,大,饭熟,
-Oma Nimi,,,Kid-in-tow,8/4/2016 15:22:34,eiole@gmail.com,Springfield,Satakunta,Islanti,Pöötöimiiköääkköseť,Al Khaleb bin Rasmus,
-Isaac Asimov,,,Child,8/4/2016 15:22:59,ike@asimov.com,New York,New York,USA,Isaac,Asimov,
-Maija Mehiläinen,,,First Worldcon,8/4/2016 15:23:22,maija.mehilainen@thehive.com,Tampere,Pirkanmaa,Finland,Maija,Mehiläinen,
-Seleya Smith,,,Child,8/4/2016 15:23:49,vulkan@mail.it,Florence,Tuscany,Italy,Seleya,Smith,66
-K Tomato,,,Youth,8/4/2016 15:27:24,moviesRus@planet9.space,Smallville,Gotham,Mars,Killer,Tomato,
-Radamsa,,,Kid-in-tow,8/4/2016 15:32:14,,"Sink, Under the",,,Snadaff,Uhmuh,67
-Bilbo Baggins,,,First Worldcon,8/4/2016 15:34:21,bilbo@hobbittown.com,The Shire,The Shire,Middle Earth,Bilbo,,
-Ildikó James,,,Adult,8/4/2016 15:35:15,ijames@ei.oo,Budapest,,Hungary,Ildikó,James,68
-Nikke Knakkerton,,,Adult,8/4/2016 15:44:19,nikke@mct.blergh,Kyritz,Landkreis Ostprignitz-Ruppin,Brandenburg,Nikke,Knakkerton,69
-Mary Poppins,,,Adult,8/4/2016 15:44:33,mary.poppins@banksresidence.co.uk,London,London,UK,Mary,Poppins,
-Iina Kuusipuu,,,First Worldcon,8/4/2016 15:52:08,Kuusipuu@sysimetsa.fi,Korpi,,Maameri,Sanni,Aurinkoinen,
-Heikki Bae,,,First Worldcon,8/4/2016 15:57:15,bae@baebae.com,Baelandia,Baemaa,Baeland,Heikki,Bae,
-Klingon Number 1,,,Adult,8/4/2016 15:58:30,NumberOne@mac.com,San Jose,CA,USA,One,,
-Smedley T. Smedford,,,Adult,8/4/2016 16:00:44,smedsmed@smedley.org,Galaxy City,Rhode Island,USA,Smedley,Smedford,70
-Mikko Mallikas,,,Adult,8/4/2016 16:03:59,mikko@mallikas.fi,,,Sweden,Mikko,Mallikas,
-Jim Stoneheart,,,Adult,8/4/2016 16:08:46,WillRiseAgain@sunspear.se,Caemlyn,Eros,The Belt,Amos,Avasarala,
-Tootles McBride,,,Adult,8/4/2016 16:10:14,Tmb@example.org,Birmingham,Staffordshire,United Kingdom,Toot,McBride,71
-Kimiko Weasley,,,First Worldcon,8/4/2016 16:12:29,Immadeofcats@gmail.com,Portland,OR,USA,Kimiko,Weasley,
-Jo Helder,,,Adult,8/4/2016 16:13:36,jo.helder+Wcon@gmail.com,Cambridge,Cambridgezhire,United Kingdom,Joanne,Helderine,
-Qwertyuiopasdfghjklzxcvbnm1 Qwertyuiopasdfghjklzxcvbnm2 Qwertyuiopasdfghjklzxcvbnm3 Qwertyuiopasdfghjklzxcvbnm4 Qwertyuiopasdfghjklzxcvbnm5 Qwertyuiopasdfghjklzxcvbnm6 Qwertyuiopasdfghjklzxcvbnm7 Qwertyuiopasdfghjklzxcvbnm8 Qwertyuiopasdfghjklzxcvbnm9 Qwertyuiopasdfghjklzxcvbnm10,,,First Worldcon,8/4/2016 16:17:29,!#$%&'*+-/=?^_`{|}~@invalid.net,😎😡,∆∏,✈︎⚓︎,,,72
-Minnie Musa,Supporter,8/4/2016 16:17:41,,,umustbjoking@hercmail.org,Victoria,BC,Canada,Minnie,Musa,73
-"Help, I'm stuck in an elevator!",,,Adult,8/4/2016 16:26:09,helphelphelp,Essen,,Germany,No,Name,
-Bill Bobbington,,,Adult,8/4/2016 16:28:35,Dfghhj@ffhhk.com,Newtownabbey,Antrim,United Kingdom,Bill,Bobbington,
-大 吳,,,Adult,8/4/2016 16:29:46,大吳@wu.id.au.example.invalid,beijing,,中国,中小,吳,
-Fred Perry ,,,Adult,8/4/2016 16:34:37,Fred@perry.com,North Hollywood ,Ca,Usa,Dave,Dave,
-Hugh Kyril Sacristan,,,Adult,8/4/2016 16:36:56,hughsac@avevalecollege.org.uk,Avevale,Kingsland,Britain,Paul,Harding,
-Yrjö Äijö,,,Adult,8/4/2016 16:37:28,yrjoaijo@jippii.com,Nikolainkaupunki,Länsi-Suomi,Finland,Yrjö,Äijö,74
-Barbara Wellesley,,,Youth,8/4/2016 16:42:07,bewell@aCloud.com,Dublin,,Ireland,Barbara,Wellesley,
-Crochet Queen,,,Kid-in-tow,8/4/2016 16:44:00,notaknitter@yarnlovers.com,Sheepsville,Wool Land,Yarnheads,Crochet,Queen,
-Ääkköñen Ääkötsalo,,,Adult,8/4/2016 16:51:07,erich.mielke@stasi.dd,Kerakekoski,,Finland,Ääkkönen,Ääkötsalo,75
-Justin Treudeau,,,First Worldcon,8/4/2016 16:56:14,dontask@gmail.com,Canada,Canada,CANADA,Justin,McSexy Treudeau,76
-叶文洁,,,First Worldcon,8/4/2016 16:57:37,yewenjie@ttbp.com,长春,吉林,中国,统帅,文洁,77
-C Lê,,,First Worldcon,8/4/2016 16:58:07,cle@yahoo.co.uk,NYC,New York,USA,,Lê,
-小灵通,,,Adult,8/4/2016 17:00:50,future@faa.com,上海,上海,中国,小,灵通,78
-The Doctor,,,Adult,8/4/2016 17:00:58,TenthDoctor@tardis.com,Sexy,Gallifrey,The Universe,The,Doctor,79
-Zaphod II,,,First Worldcon,8/4/2016 17:01:08,Blaster Way,Blaster City,YN,Caprica,Zaphod,II,
-Bellosi,Supporter,8/4/2016 17:02:11,,,Supporterbel@nix.com,Blueden,SK,Canada,Blue,Silly,80
-Ezekiah Horobowicz,,,Adult,8/4/2016 17:05:33,sweetie@edgeoftheunivers.com,Picklegritz,Maine,USA,E-Z,Horobowicz,81
-Medusa Sanctuary,,,Adult,8/4/2016 17:06:34,medusa4tehgillz@gmail.com,Lewisporte,Newfoundland ,Canada,Medusa,Sanctuary ,82
-JRR Lewis,,,Adult,8/4/2016 17:06:40,inklings@pub.co.ukish,Cair Paravel,Mordor,Narnia,JRR,Lewis,83
-Ürsa,,,First Worldcon,8/4/2016 17:07:47,wårldkøn@fakeaddress.gn,მეტროპოლია,நாங்கள்,Ïs,Ø;rperth,ცხენი,84
-Marion Morrison,,,Adult,8/4/2016 17:08:25,Theduke@fortapache.mil,San Antonio,Tx,USA,The,Duke,
-Ifihada Hammer,,,Child,8/4/2016 17:11:34,,,,,,,85
-Harriet Pottery,,,Adult,8/4/2016 17:15:11,,,,,,,
-Freddy Mercury,,,Kid-in-tow,8/4/2016 17:18:24,Queen@britain.uk,Liverpool,,Great Britain,Freddy,Mercury,86
-Sir Arthur Strong (Mrs.),,,Child,8/4/2016 17:20:28,MeatLover@ding.dong,Pännäinen,Pohjanmaa,Finland,Throatwobler,Mangrove,
-Janina Kozieł,,,First Worldcon,8/4/2016 17:21:31,jkoziel@o2.pl,Gdańsk,Pomorskie,Poland,Bzium,Ąęóśćż,
-Rangoon Obama,,,First Worldcon,8/4/2016 17:24:27,Big.pits@bhs.com,Prague,Oklahomer,India,Ranulph,The Uninspired,87
-Max Syöttöpaine,,,Adult,8/4/2016 17:28:07,max@syottopaine.fi,Tampere ,,Finland,Max,Syöttöpaine,
-Fresh Prince,,,Adult,8/4/2016 17:30:15,will@jazzyjeff.com,Bel Air,California,USA,Will,Smith,
-James Tiberius Kirk,,,Child,8/4/2016 17:31:58,jtkirk@starfleet.org,,Iowa,USA,James,Kirk,
-Lomion,,,First Worldcon,8/4/2016 17:32:04,lomion@gondolin.com,Gondolin,Tumladen,Beleriand,Maeglin,Lomion,
-Floney McFlooloo,,,Kid-in-tow,8/4/2016 17:32:58,spam@spam.spam.spam.spam.spam,Guantanamera,Guantanamera,GuantanaMERa,Floney,McFlooloo,88
-BigNostrils Tony,,,Kid-in-tow,8/4/2016 17:34:53,Sexyfishlips@aol.com,Bumshart,Nebrahoma,Norwegia,BigNostrils,Tony,
-Arthur C. Clarke,,,Child,8/4/2016 17:35:26,childhoods@end.com,Rama,,Rama,Arthur C.,Clarke,89
-Alanna of Trebond and Olau,,,Adult,8/4/2016 17:35:58,thelioness@tortall.com,Port Caynn,Olau,Tortall,Alanna,Olau,
-Bob bobman ,,,Adult,8/4/2016 17:36:25,Sdh@f.com,New York ,Ny,United States ,Bob,Bobman,90
-Poke Stop,,,First Worldcon,8/4/2016 17:39:24,Pokestop@stop.com,Beuford,DC ,Usa,Poke,Stop ,91
-Americas Next Top Fondler,,,Adult,8/4/2016 17:40:03,Buttfulloftrumpets@compuserv.net,Crincklesack,Clitoropolis,Geidi Prime,Barry,McCockiner,
- יצחק בן אברהם,,,Child,8/4/2016 17:40:26, יצחק@אינטרנט.הו,כְּנַעַן,כְּנַעַן,ישראל, יצחק, בן אברהם,
-Anthony Caracterus Flewellen Gripewater-Thynne IV,,,Adult,8/4/2016 17:41:59, 囍@example.com ,Luna,Luna,N/A, 囍 ,,92
-Tasha Lennhoff ,,,Adult,8/4/2016 17:51:04,tasha_turner@fake.com,Highland Park,NJ,USA,Tasha,Turner Lennhoff ,
-Asthore MacRowyn,,,First Worldcon,8/4/2016 17:51:20,asthore@brittanis.larp,Cornerstone,Albion,Brittanis,Asthore,MacRowyn,
-Keladry,,,Adult,8/4/2016 17:53:55,ladyknight@tortall.org,Mindelan,Northern Tortall,Tortall,Keladry,Mindelan,
-JRR Tolkien ,,,First Worldcon,8/4/2016 17:55:21,Jrrt@middleearth.com,Minas Tirith,Gondor ,Gondor ,Professor,T,93
-Nikolaj Ivanovich Lobachevsky,,,First Worldcon,8/4/2016 17:55:49,Петербург@xmail.com,Петербург,ny,Петербург,Петербург,Петербург,
-Bènnifër Fôcjestār,,,Adult,8/4/2016 17:57:26,The Willow Arms,Ætherton,Bârstow,US,Puddin,Täyn,
-Fred Mouse,,,First Worldcon,8/4/2016 18:00:34,fred.mouse@aol.online,Yellow Knife,,Canada,Fred,,
-Rhys Gwyn 'ten Boom,,,First Worldcon,8/4/2016 18:00:39,rhysgwyn@llys.cy,Llangollen,Cantre' Gwaelod,Cymru,Rhys Gwyn,ten Boom,
-Duncan McLeod,,,First Worldcon,8/4/2016 18:01:17,dmc@skyfall.sco,Timbuktu,,The future,Hello,World,94
-Marialegre Alfarero,,,Adult,8/4/2016 18:09:22,,Mexico City,Guanajuato,Mexico,Marialegre,Alfarero,95
-Vanta Black,,,First Worldcon,8/4/2016 18:10:46,vantaawkbot12@hotmail.com,Derry,Maine,USA,Vanta,Black,96
-Lady Peter Wimsey,,,Adult,8/4/2016 18:13:38,detectivemoll@writ.uk,London,,England,Harriet,Wimsey,97
-Bjørn Årnót,Supporter,8/4/2016 18:14:04,,,bjorn.arnot@not.fi,Vega,-,Finland,Bjørn,Årnót,
-"Foo Bar, Jr.",Supporter,8/4/2016 18:16:30,,,foo@bar.comz,Foo City,Bar State,Foobar Republic,Allan,Foobar,98
-Daavid Inkeroinen ,,,Kid-in-tow,8/4/2016 18:21:34,Simppu.lsunda@usa.net,Östersundom,Machiavelli,Sedna,Taavi,Inkkula,99
-Okay,,,First Worldcon,8/4/2016 18:24:42,doodaa@deedoo.au,Lunar Orbit,Skullcity,Mars,Sizzle,Pop,100
-Brew Haha,,,First Worldcon,8/4/2016 18:26:26,brewhaha@yahoo.net,Beer City,Illinois,USA,Brew,,
-Lady Di,,,First Worldcon,8/4/2016 18:29:04,Di-NaMight@tower of London. Uk,The Moors,Left of Center,Half Baked Potato Land,Lady Di,,
-Smee Smee,,,First Worldcon,8/4/2016 18:45:50,tigers@arecute.com,London,London,United Kingdom,TIGERS,ARE-CUTE,101
-Jo Bitfsplk,Supporter,8/4/2016 18:46:40,,,jo@jobitfsplk.com,Bitfsplkville,VT,USA,Jo,Bitfsplk,102
-Ralph Malph,,,Adult,8/4/2016 18:46:43,devnull@deltos.com,McKinney,TX,US,Ralph,Malph,
-Melvin Morsmere,,,Adult,8/4/2016 18:50:09,melvin@squidlips.com,Tacoma,WA,USA,Peduncle Q.,Mackinaw,103
-Skarrin Kilgarrin,,,First Worldcon,8/4/2016 19:01:12,Blee@bloo.net,Skarrinville,WA,USA,Skarrin,Kilgarrin,104
-Renauld Franenstien,,,First Worldcon,8/4/2016 19:07:28,REnnie@nappy.yuk.uk,London,London,Uk,Rennie,Frank,105
-Sabrina Vorkosigan,,,Kid-in-tow,8/4/2016 19:09:14,Daddy@nappy.yuk.uk,Newcastle,The grim Northlands,UK,Kitty ,Kat,
-Soup Dragon,,,Adult,8/4/2016 19:10:52,soupdragon@Clangers.planet,Star City,Asteroid belt,UK,Soupy,,
-Ford Prefect,,,Adult,8/4/2016 19:12:03,Ford@hitchhikersguide.vogon,London,UK,,Ford,,
-Pinkie pie,,,Child,8/4/2016 19:13:09,mummy@nappy.yuk.uk,Bristol,Avon,UK,Baby,,
-tweety pie,,,Youth,8/4/2016 19:14:22,bird@bird.bird,Birdsvelle,,UK,Tweety,,
-Mrs Slartibartfast,,,First Worldcon,8/4/2016 19:19:48,slartibartfast@hotletter.com,Brigadoon,Teuchterland,Scotland,Istina,Pronkovic,
-Rękosław Samodzielny,,,First Worldcon,8/4/2016 19:20:43,RasiaSamosia@buziaczek.wp.pl,Chrząszczyżewoszyce,Łękołody,Poland,Rękosław,Samodzielny,106
-Galadriel of House Finarfin,,,Adult,8/4/2016 19:20:47,galadriel@lothlorien.fi,LothLorien,woods,Middle-earth,Galadriel,Galadriel,
-Tina Belcher,,,Youth,8/4/2016 19:20:49,tina@burgertown.net,Seymour's Bay,Rhode Island,United States,Dina,Belcher,107
-Legolas aka the dainty footed elfling,,,First Worldcon,8/4/2016 19:27:17,legs-so-daint@elfdom.elf,Woodland Realm,Mirkwood,Middle Earth,Legolas,Thranduilson,
-Bert and Ernie,,,First Worldcon,8/4/2016 19:33:07,thisisatest@test.com,Oklahoma City,OK,USA,Bert,Ernie,108
-Putinoid,,,First Worldcon,8/4/2016 19:43:11,idiot@kremlin-kgb.com,Северополюсовск,Лагерь,Российская Умудряция,Путиноид Ленинович, Сталин-Добанутый,109
-Євроїжак / Eiroizhak,,,Child,8/4/2016 19:45:49,izhachek@super-ukraine.com,Бердичів,Вінницька область,Україна,Євросла,Українець,
-Badger Comedian,,,Adult,8/4/2016 19:57:11,mail@badgerandboodle.com,Sedgely ,West Midlands ,England ,Badger ,McGinley ,
-Василий Пупкин,,,Adult,8/4/2016 19:57:30,"Зареченская губ., г. Мухосранск, ул. Нахренацкая, 18",Мухосранск,Зареченская губерния,Рутения,Василий,Пупкин,
-Edgar Allan Poop,,,Child,8/4/2016 19:57:50,edgar@example.com,Somewhere over the Rainbow,Nowhere,Disunited Kingdom,Edgar,Allan,110
-Висисуалий Лаханкин,,,First Worldcon,8/4/2016 20:02:15,"Молдаванка, Воронья слободка, 3",Черноморск,Черноморская область,Портофранция,Висисуалий,Лоханкин,111
-Вовочка Ложкин,,,Child,8/4/2016 20:05:25,"Старых Козлов, 15, кв. 6",Урюпинск,Симбирская губ.,Русланд,Вовочка,Ложкин,
-Twix the Mad Dog,,,Kid-in-tow,8/4/2016 20:18:42,Twix@twixietwix.fm,Toronto,Surrey,Belarus,Twix,Doctor,
-Valrhona Moose,,,First Worldcon,8/4/2016 20:21:28,valrhona@chocolatemoose.org,Birmingham,West Midlands,England,Valrhona,Moose,
-לגיטימי חגמצגמדל,,,Adult,8/4/2016 20:22:56,מכמגמג@חגנכמגל,"ידי הגמל,",מכלא׳,צכלכלםא,ממדיכ(,נסיכי<,112
-Lisa-Oscar de la Kärvistys,,,First Worldcon,8/4/2016 20:23:17,foo+bar@mail.example.org,Ougadougou,-,Burkina Faso,<3,de la Kärvistys,
-Wrigley,,,Adult,8/4/2016 20:23:18,wrigley@chocolatemoose.org,Solihull,West Midlands,United Kingdom,Wrigley,Caterpillar,
-<script>alert(1)</script>,,,Child,8/4/2016 20:28:22,foo.bar@example.ninja,<script>alert('2')</script>,"<script>alert(""3"")</script>",<script>alert(4)</script>,<SCRIPT SRC=http://xss.rocks/xss.js></SCRIPT>,"<IMG SRC=""javascript:alert('XSS');"">",113
-Fakey MacFakerston,,,Adult,8/4/2016 20:31:09,fmf@fakey.example.com,Portland,OR,USA,Fake,MacFakerston,114
-x' OR full_name LIKE '%Bob%,,,Youth,8/4/2016 20:34:48,x' AND email IS NULL; --,x' AND 1=(SELECT COUNT(*) FROM tabname); --,anything' OR 'x'='x,Finland,x'; DROP TABLE members; --,Hacker,115
-Kaywinnet Lee Frye,Supporter,8/4/2016 20:48:56,,,kaylee_unicorn@serenity.brown,Classified,Classified,a Core planet,Kaylee,Fry,116
-Falsity Tanner,,,First Worldcon,8/4/2016 20:51:16,Falsity@RDC.com,Wales,MA,USA,Fanny,Tanner,117
-Spiro T Agnew,,,First Worldcon,8/4/2016 20:54:39,spiro@agnew.com,Washington,DC,USA,Spiro,Agnew,118
-Arya Stark,,,Youth,8/4/2016 20:56:51,winter@is.coming,Winterfell,The North,Westeros,A Girl has,No name,119
-Rommi,,,Adult,8/4/2016 21:04:08,Caribean@car,Havanna,,Pirate union,Rommi,Blackbeard,120
-FitzChivalry Farseer,Supporter,8/4/2016 21:06:53,,,fitzchivalry.farseer@sixduchies.gov,Buckkeep,Buck,Six Duchies,Fitz,Farseer,
-Kettricken of the Mountains,,,Adult,8/4/2016 21:08:14,Kettricken.Queen@sixduchies.org,Buckkeep,Buck,Six Duchies,Kettricken,,
-Chivalry Farseer,,,Adult,8/4/2016 21:09:57,Chivalry.Prince@sixduchies.org,Buckkeep,Buck,Six Duchies,Prince Chivalry,Farseer,121
-"Michael ""Goob"" Yagoobian",,,Adult,8/4/2016 21:23:52,goobian@goobmail.net,Chicago,Illinois,United States of America,Bowler Hat,Guy,
-Vitruvius,Supporter,8/4/2016 21:29:53,,,masterbuilder1937@lego.movie,Amersterdam,North Holland,Kingdom of the Netherlands,Morgan,Freeman,122
-Ariana Yli-Yrity's,,,First Worldcon,8/4/2016 21:38:42,Yli-yritys@jokuposti.fi,Kontu,-,Hobittila,Ary,YY,
-Alana Landfall Capulet,,,First Worldcon,8/4/2016 21:39:08,badasslandfallianmama@run.hide,Wingspan,West Side,Landfall Landmass,Alana,Saga,
-Lola Numjaker,,,First Worldcon,8/4/2016 21:57:15,yawanityagotit@somemail.ca,Moscova,,Monrovia,Topheavy,Woman,123
-Regnad Kcin,,,Adult,8/4/2016 22:18:38,danger@fake.com,The City,Solidstate,Freedonia,Regnad,Kcin,124
-Paradoxical Astral Fairy,,,First Worldcon,8/4/2016 22:23:21,fairy@none.com,Utopia,,Atlantis,You're Not,Serious,
-Noodle McNoodface,,,First Worldcon,8/4/2016 22:31:37,Noodynoodnoodnoodlington@nood.com,Cottonwood,Arizona,United States,Nana,McNoodFace,125
-Silly Lilly vonWigglesbottom,,,Youth,8/4/2016 22:32:55,actuallymycat@actuallymycat.com,Cat Tower,VA,Roanoke,Kitteh,Hsu,
-Kathryn Airey,,,Youth,8/4/2016 22:34:33,kja@maths.mf.ac.uk,Okehampton,Devon,United Kingdom§,,,126
-River Song,,,Adult,8/4/2016 22:42:28,river.song@51stcentury.net,Everywhere,Everywhere,All of time and space,,,
-Shadow Moon,,,Adult,8/4/2016 22:45:19,shadow@moon.com,House on the Rock,Wisconsin,America,Shadow,Moon,
-Τηλέμαχος,,,Youth,8/4/2016 22:47:32,,,Ιθάκη,Ελλάδα,Τηλέμαχος,,127
-Breq Mianaai,,,First Worldcon,8/4/2016 22:50:39,captain@mercyofkalr.rd,Athoek Station,Athoek,The Radch,,<i>Justice of Toren</i>,
-I have a public first name but not a public last name. Let's see if it gets recorded in the database properly.,Supporter,8/4/2016 22:58:33,,,awkward@example.com,Bristol,Avon,England,Venturus,,
-Abby Yates,,,Adult,8/4/2016 23:10:13,theyRreal@ghostbusters.ca,"Neutron City, Alberta",Alberta,Kanata,Keymaster,Zod,
-Erin Gilbert,,,Adult,8/4/2016 23:14:23,respectMyauthority@ghostbusters.ca,Plasma Town,Black Hole,Miigwetch,Doctor,Science,
-Jillian Holtzmann,,,Adult,8/4/2016 23:15:59,lickmygun@ghostbusters.ca,Vortex,Astral Plane,Universe,The Best,Toys,
-Patty Tolan,,,Adult,8/4/2016 23:17:23,HistoryGoddess@ghostbusters.ca,Subway,NYC,Planet Eart,Lesley,Jones,
-Anthea Sykes,,,Child,8/4/2016 23:23:09,awful@sykesfamily.co.uk,An unnamed town,An unnamed county,England,"""Awful""",Sykes,
-Oobedoob Benubi,,,First Worldcon,8/4/2016 23:31:22,Starfish1@domainname.fish,Springfield,Az,Usa,,,128
-Boaty McBoatFace,,,First Worldcon,8/4/2016 23:45:32,marvinkmooney@pleasegonow.com,Kalamazoo,Timbuktu,Spam,,,
-Sophie Meier,,,Youth,8/4/2016 23:47:12,sophia@zoeterwoude.nl,Leiden,Zuid-Holland,Nederland,Sophie,Meier,
-Mario di Noble,,,First Worldcon,8/4/2016 23:48:20,Mario@whatever.joke,Pashmina,Indiana ,USA ,Mario,De noble,129
-π∆q Bach,,,First Worldcon,8/4/2016 23:53:14,harpsichord@music.net,,,,,,
-Pernickity Tests,,,First Worldcon,8/4/2016 23:59:10,pernickity@example.com,Pernickity,A pernickity place,Pernickity States of Acirema,Pernickity,Pernickityboots,130
-Alan Diehl,,,Adult,8/5/2016 0:07:44,a.diehl@gnail.con,Double Trouble,NJ,USA,Al,Diehl,
-FarkleBuns,,,Adult,8/5/2016 0:13:08,farklebuns@fakeip.net,Haad Yai,Songkhla,Thailand,Fred,Farklebuns,
-Rock LeBateau,,,Adult,8/5/2016 0:25:16,Rock.LeBateau@gmail.com,Nottingham,Nottinghamshire,Great Britain (aka U.K.),Rock,LeBateau,131
-Hypatia of Alexandria,,,First Worldcon,8/5/2016 0:49:00,nowhere@example.foiwr,Tycho Under,,Luna,Ann,Onyma,
-Constitutional Crisis,Supporter,8/5/2016 0:51:15,,,thiswouldactuallywork@mailinator.com,New Paltz,New York,United States,Suzette,Smith-Singh,132
-Metso Pekoni,,,First Worldcon,8/5/2016 1:14:51,pekoni.metso@gmail.com,Helsinki,Uusimaa,Finland,Metso,Pekoni,133
-Jussi Halal-Aho,,,Child,8/5/2016 1:18:49,upponalle@gmail.com,Helsinki,Uusimaa,Isämmaa,Jussi,Halal-Aho,
-Miles Vorkosigan,,,Adult,8/5/2016 1:21:54,Miles@vorkosigan.bar,Hassadar,Dendarii,Barrayar,Miles,Naismith,134
-Gunnar Aasen,Supporter,8/5/2016 1:34:30,,,my@yes.no,Bergen,,Norway,Gunnar,Aasen,
-Grynet Å,,,First Worldcon,8/5/2016 1:38:53,,Å,Lofoten,Norway,Grynet,Å,135
-Khal Drogo,,,Kid-in-tow,8/5/2016 1:43:01,dothrakirulez@gmail.com,Horseback,Essos,Essos?,Khal,Drogo,
-Colorful Designer,,,Adult,8/5/2016 1:51:36,dontyouwish@wiseass.com,Colorful,Colorado,U.S.A.,Colorful,,136
-Bill Bogus Weinberg,,,Adult,8/5/2016 1:52:37,bogus@cloud13.net,Bronx,NY,United States,Bogus,Claret,137
-Segreta Castro,Supporter,8/5/2016 1:54:26,,,segreta@bogus.org,Brooklyn,NY,United States,Mysteria,Z,
-Alan Fakir Smithee,,,First Worldcon,8/5/2016 1:56:48,asf@bogus.org,New York,NY,United States,Fakir,Q,
-J.M. McDoodle-o'wampus,,,Child,8/5/2016 2:11:56,Ddd@,Alton on Green Homeland ,Misisippi,U.s.a,Folgelblastervistacondragonpottlespudwumpusjoe,D,138
-Řehoř Vaňčík,,,Adult,8/5/2016 2:16:11,janvanek.cv@gmail.com,Praha,,Czechia,Řehoř,Vaňčík,
-Bilbo Baggins I,,,First Worldcon,8/5/2016 2:18:22,bilbo@theshire.net,Hobbiton,The Shire,Middle Earth,Bilbo,Baggins,
-Rev Byron Dingleblatt,,,Kid-in-tow,8/5/2016 2:41:50,@dding.a.malformed.address,Rutabaga,,Freedonia,Caractacus,,
-Penn Gwyn,,,Adult,8/5/2016 2:51:28,penngwyn@gmail.com,Toronto,Ontario,CANADA,Trob,Exil,139
-Natasha Yar,,,Kid-in-tow,8/5/2016 4:20:28,nyar@enterprise.net,Coalition,Cadres,Turkana IV,Tasha,Yar,140
-Elizabeth Thrall,Supporter,8/5/2016 4:38:31,,,Dolly@aol.com,Heaven,PA,USA,Dolly,Thrall,
-Natalie Mestecom,,,Adult,8/5/2016 4:54:26,nat.mestecom@aol.com,Wordpress,Somewhere where there's winter,USA,Natalie,Mestecom,
-Katherine Astra,Supporter,8/5/2016 4:55:30,,,kat.astra@aol.com,Wordpress,"Somewhere cold, too",USA,Kat,Astra,
-Graciela Fairbanks,,,Adult,8/5/2016 4:56:42,g.fairbanks@aol.com,Somewhere where people can have farms,Ohio!,USA,Gracie,Fairbanks,
-Hana Takahashi,,,Adult,8/5/2016 5:02:26,hana.takahashi@castle.com,Uhhh not sure,Also unsure!,USA!,Hana,Takahashi,
-Mira Addleton,,,Adult,8/5/2016 5:03:27,mira.addleton@castle.com,"Um, dunno",Sigh...dunno,USA!,Mira,Addleton,
-Simian Smallsby,,,Adult,8/5/2016 5:32:07,Noone@nowhere.org,Sebastopol,RI,Gondwanaland,Misty,Ayes,
-Rixenchanter,,,Adult,8/5/2016 5:35:04,Rixenchanter@world.c,West Freeport,Freeport,Antonia,Rix,Enchanter,141
-Ricardo,,,Kid-in-tow,8/5/2016 5:35:57,Bleep@bloop.ca,Stratford-Upon-Avon,,Republic of Northern Ireland,Hamid,D'Sousa,142
-Eve Dallas,,,Adult,8/5/2016 5:36:34,Edallas@nypsd.gov,Nooyawk,NY,Irish Republic,,Dallas,
-Gggraaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaargh Snaaaaaaaaàãåâäæerf,,,First Worldcon,8/5/2016 5:40:23,Rrrgh@grrruph.org,Piltdown,Florida,.,Gràaâåäæaaaaaaaaaaaaaaaaaaaaaàaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaargy,Graaaaãåâaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaergh,143
-Nudoru soss,,,First Worldcon,8/5/2016 6:03:30,Nudorusoss@nevermind.org,Sonora,Sleepyhead,Dreamland,Nudoru,Soss,144
-Santa Clause,,,Adult,8/5/2016 6:40:25,sdkjfhalsdkjfhk@djhksdjhfksjdh.com,North Pole,Arctic Ocean,skjdhfskdjfhk,Santa,Claws,145
-T. G. Writer,,,Adult,8/5/2016 6:44:56,tgwriter@gmail.com,Word Processor,Macintosh,Apple,TG,Writer,146
-Tom of Finnair,,,Adult,8/5/2016 6:49:59,Tom@Finnair.com,Kaarina,Turku,Finland,Tom,,147
-Nalle Puh,,,First Worldcon,8/5/2016 7:11:04,Nalle@pu.h,Kouvola,,Westeros,Nöle (Nalle),Puh,
-Brittany Anne Bifftad,,,First Worldcon,8/5/2016 7:47:58,brittany@androbovine.com,The Glades,Tofftown,Luna,Britty,Bifftad,148
-Drugged Out Zombia,Supporter,8/5/2016 8:00:31,,,doz@totallystoned.org,Weed,CA,USA,Druggo,Zombie,
-Cihuapilli Apipiyalotzin,,,Adult,8/5/2016 8:01:49,CihAppip@gmail.com,NoPattiztlan,OZ,Fairy,Cihuapilli,Apipiyalotzin,149
-Pier Gerlofs Donia,,,Adult,8/5/2016 8:56:48,FrisianRebelPirate@yahoo.com,Kimswerd,Friesland,Netherlands,Pier,Donia,
-Moggie McGato,,,First Worldcon,8/5/2016 9:29:42,Cathouse@fakemail.com,Katzenburg,Felidae,Meow!,Moggie,McGato,150
-Hideki Motosuwa,,,First Worldcon,8/5/2016 10:54:07,hideki.motosuwa@gmail.com,Tokyo,,Japan,Hideki,Motosuwa,151
-Alex Woodley,,,Adult,8/5/2016 11:20:09,alex.woodley@example.com,Winchester,,England,Alex,Woodley,152
-Poplock Duckweed,,,First Worldcon,8/5/2016 11:46:55,poplock@example.com,Pondsparkle,,Zarathanton,Poplock,Poplock,
-Fred the Great,,,Youth,8/5/2016 12:22:19,fredthegreat@fakemail.com,Mars,Milkyway,Universe,Fred,the Great,153
-Sheila,,,Adult,8/5/2016 12:23:19,someone@bigpond.net,Perth,Western Australia,Australia,Sheila,Docker,154
-Biggs McPearsen,,,Child,8/5/2016 12:23:33,biggsyboo@fakemail.com,Undulasia,BC,Amenada,Biggsy,McPearsen,155
-Helena Robertson,Supporter,8/5/2016 12:27:26,,,hrobertson@geocities.com,Bangor,Maine,USA,Helena,Robertson,
-Tintin Windowes,,,First Worldcon,8/5/2016 12:27:33,snowy@tintin.com,Townsville ,Denial,Canadaustralia,Tintin,Windowes,
-Frank Zappa,,,First Worldcon,8/5/2016 12:28:23,zappa@frank.com,caprica,aldur,zootopia,Frank,Zappa,
-Ashley Williams,,,First Worldcon,8/5/2016 12:31:24,ashley.m.williams@edenprime.mil.sa,San Juan,Puerto Rico,USA,Ashley,Madeline,156
-meow,,,Adult,8/5/2016 12:33:25,meow@meow.meow,meow,meow,meow,meow,meow,157
-Stephanie Brown,,,Youth,8/5/2016 12:33:38,Spoiler@batgirl.com,Gotham,,United States,,,
-Ian,Supporter,8/5/2016 12:34:02,,,Iandoodoo@fake.cum,Cheesusville,Venus,Potatopia,Johan,Bach,158
-Blake Langsam,,,First Worldcon,8/5/2016 12:36:37,,Brooklyn,Ny,United States ,Blake,Lamgsam,159
-Samwise Gamgee,Supporter,8/5/2016 12:36:45,,,thegardener@potatoes.net,Hobbiton,Westfarthing,Shire,,,160
-Not Slim Shady,,,Kid-in-tow,8/5/2016 12:38:07,itotallyamthough@hmail.com,Mars,Olympus Mons,Mars,Slim,Shady,161
-Gromble Smindgub,,,First Worldcon,8/5/2016 12:38:30,antimattereater@hotmail.com,Void,Bigger Void,Biggest Void,Fence,Post,162
-Chloë Glass,Supporter,8/5/2016 12:38:46,,,explodingpinapples@hotmail.com,Shantalla,Galway,Ireland,,,163
-Albus Percival Wulfric Brian Dumbledore,,,Adult,8/5/2016 12:45:49,iopen@the.close,Kings Cross,Hogwarts,Your Mom,Albus,Dumbledore,164
-Jon Pertwee,,,First Worldcon,8/5/2016 12:47:48,definitely@email.com,london,ohio,china,sean,roberts,165
-John Tapwaters,,,Adult,8/5/2016 12:50:59,drinkwater@tap.com,Wet City,stateofdecay,Wetlands,John,Tapwaters,
-Arram Draper,,,First Worldcon,8/5/2016 12:51:58,arramdraper@google.com,gottingen,Lower Saxony,Germany,Numair,Salmalin,166
-Ella Byrne,,,First Worldcon,8/5/2016 13:00:57,whatifitsreal@mail.com,Casablanca,Dude IDK,Moonland,Elgernon,Bond,167
-"Misty McBubbles, Queen of the Moon",,,First Worldcon,8/5/2016 13:03:30,fiddledeedee@wonkafactory.com,Glasgow,Manitoba,Switzerland,Angelica,Snigglefritz,168
-Mona Choudhury,,,Child,8/5/2016 13:07:09,Mona@spce.org.nz,Tiamat,Tangaroa,Tangaroa,Mo,Choudhury,
-Eleven,,,Child,8/5/2016 13:11:42,E11e@hawkins.in,The Upsidedown,Indiana? I guess?,US,Eleven,What's a last name,
-Leina Rofe,,,First Worldcon,8/5/2016 13:18:23,Leina.Rofe@magi.jevu.ac.ke,Jevus,,Kenaan,Leina,Rofe,169
-Sessa Liandra,,,First Worldcon,8/5/2016 13:18:29,sessa.l@gmail.com,Hamburg,Hamburg,Germany,Sessa,Lia,
-Morgana Nightflower,,,Adult,8/5/2016 13:19:53,morgana@ghostbusters.com,New York City,New York,Transylvania,Morgana,Nightflower,170
-Testy McTestface,,,First Worldcon,8/5/2016 13:20:54,testy@testface.com,Testoma,OR,USA,Testy,McTestface,171
-Hrothgar Gil,,,First Worldcon,8/5/2016 13:23:38,gil.gar@totesandemail.com,Moontopia,Yue,The Moon,Abili,Asherbanerpal,172
-Anne Shirley,,,First Worldcon,8/5/2016 13:24:04,annelovesgables@gmail.com,Avonlea,Prince Edward Island ,Canada,Anne,Shirley,173
-Rosalia Disodium,,,Adult,8/5/2016 13:31:52,Radio@immexes.com,Melbourne,VIC,Australia,Rosalia,Disodium,174
-sans skeleton,,,Adult,8/5/2016 13:32:37,skelepun@undernet.ut,Snowdin,The Capitol,The Underground,Sans,Skeleton,
-Joss Page,,,First Worldcon,8/5/2016 13:32:42,shinyexplodythings@spacedad.com,Seattle,WA,United States,Jocelyn,Page,
-Lorem Ipsum,,,First Worldcon,8/5/2016 13:33:28,willthiswork@email.com,Sint-Niklaas,Oost-Vlaanderen,Belgium,Lorem,Ipsum,
-Papyrus Skeleton,,,Adult,8/5/2016 13:34:06,thegreatpapyrus@undernet.ut,Snowdin,The Capitol,The Underground,Papyrus,Skeleton,
-Alia Flitspitch,,,First Worldcon,8/5/2016 13:36:47,aliaflitspitch@captainamerica.com,Beirut,Beirut,Lebanon,Sokovia,Accords,175
-Marly Kerrion,Supporter,8/5/2016 13:37:18,,,Marly.Kerrion@fake.com,Derpcity,Goofball,Hotmess,Marly,Kerrion,
-Boaty McBoatface,,,Kid-in-tow,8/5/2016 13:39:44,,UK,,,Boaty,McBoatface,
-Julia Carver,,,Adult,8/5/2016 13:41:12,j.carver@havenherald.com,Haven,Maine,USA,Julia,Carver,176
-Betty Boop,,,First Worldcon,8/5/2016 13:43:08,boopboop@bedoop.com,Downtown,Toon Town,Merica,Betty,Boop,177
-Gaia Iulia,,,Kid-in-tow,8/5/2016 13:51:55,athing@aplace.com,Atlantis,Artichoke,A Place,Gaia,Iulia,
-Commander Shepard,,,First Worldcon,8/5/2016 13:52:02,dahcommandah@spectres.citadel.com,Edmonton,Alberta,Canada,Jane,Shepard,
-Celine,,,First Worldcon,8/5/2016 13:53:52,C.baby95@aol.com,Pittsburgh,Pa,USA,CeCe,,178
-Pepe le Mew,,,First Worldcon,8/5/2016 13:56:17,Bio@bs.com,Ouagadougou,Denial,Burkina Faso,The,Dude,179
-The Acolyte of Roland Jarvis,,,Adult,8/5/2016 13:57:04,acolyte@enlightened.rocks,Enlightened Compound,California,United States,The,Acolyte,
-Rosa Schlüpfer,,,First Worldcon,8/5/2016 14:00:02,rosaschluepfer@waescheleine.com,Wanneeickel,NRW,Netherlands,Rosa,Schlüpfer,
-Shev Clancy ,,,First Worldcon,8/5/2016 14:00:24,clancy@world.con,Newcastle ,NSW,Australia,Shev ,Clancy,
-Ryxl Ironheart,,,First Worldcon,8/5/2016 14:01:38,champion_ironheart@org.horde.gov,Orgrimmar,Durotar,Kalimdor,Ryxl,Ironheart,
-Agatha Heterodyne,,,Adult,8/5/2016 14:02:13,Heterodyne@Mechanicsburg.org,Mechanicsburg,ARAD,ROMANIA,Agatha,Heterodyne,
-Duke Crocker,,,First Worldcon,8/5/2016 14:05:47,crockerduke@gmail.com,Havene,Maine,United States,Duke,Crocker,180
-Andrew Baker,,,First Worldcon,8/5/2016 14:14:13,whatever@fakemail.com,Denver,Colorado,US,Andrew,Baker,
-Menachim Stilinski,,,First Worldcon,8/5/2016 14:35:11,m.a.s@gmail.com,Dordrecht,Zuid-Holland,The Netherlands,Michaelangelo,Dumoulin,
-Sam Yao,,,First Worldcon,8/5/2016 14:35:45,operator@abeltownship.co.uk,Abel Township,Yorkshire,UK,Sam,Yao,181
-Clare Fraser,,,Adult,8/5/2016 14:40:12,stonetraveler@ladybroch,Inverness,Lallybroch,Scotland,Claire,Fraser,182
-Your face,,,First Worldcon,8/5/2016 14:42:34,How about no @ why,Cats,Narnia,Paris,,,183
-John Moore,,,Adult,8/5/2016 14:48:08,john.moore@mailserver.com,Liverpool,Lancashire,United Kingdom,John,Moore,184
-Lisa de Groot,,,Adult,8/5/2016 14:49:49,liesdeg@gmail.com,Schiedam,Zuid Holland,Nederland,Lies,de Groot,
-Scarlett Bradley,,,Adult,8/5/2016 14:54:27,sb11fly@fake.com,Gary,Indiana,United States of America,,,
-Titiana Wren,,,First Worldcon,8/5/2016 14:58:12,,Paris,,France,Grace,,185
-Mitchell Connolly,,,First Worldcon,8/5/2016 14:58:49,eternaltime@hotmail.com,Toronto,Ontario,Canada,Mitch,Connolly,
-Bacta Skirata,,,Kid-in-tow,8/5/2016 15:04:06,ct1776@mynockpodcast.hnt,Tipoca City,Tipoca Sea,Kamino,Bacta,Skirata,
-Saoirse D'Arcy,,,Adult,8/5/2016 15:05:05,saoirse.darcy@gmail.com,Uxbridge,Ontario,Canada,Saoirse,D'Arcy,186
-Locke Lamora,,,Adult,8/5/2016 15:05:38,whatabastard@perelandro.org,Camorr,Camorr,Camorr,Locke,Lamora,
-Lorenzo von Matterhorn,,,First Worldcon,8/5/2016 15:05:52,lvm.beast@email.com,Whitsett,NC,United States,Lorenzo,von Matterhorn ,
-Jean Tannen,,,Kid-in-tow,8/5/2016 15:07:26,tannen@perelandro.org,Camorr,Camorr,Camorr,Tavrin,Callas,187
-Smits McGee,,,First Worldcon,8/5/2016 15:08:27,snorlax@yahoo,Chagrin Falls,Ohio,USA,Melisande,Shaharizi,
-The Doctor,,,Adult,8/5/2016 15:08:49,wibbly-wobbly@tardis.com,The Capitol,Outer Gallifrey,Gallifrey,John,Smith,
-Roland Deschain,,,Adult,8/5/2016 15:09:51,last.gunslinger@gilead.gov,,,,,,
-Shadow Moon,,,Adult,8/5/2016 15:11:42,,,,,,,
-Susannah Dean,,,Kid-in-tow,8/5/2016 15:12:21,,,,,,,
-Eddie Deen,,,Adult,8/5/2016 15:12:54,,,,,,,
-Jake Chambers,,,Youth,8/5/2016 15:13:35,,,,,,,188
-Oy,,,Child,8/5/2016 15:14:32,dress,ity,ovince,untry,Oy!,Ambers!,
-Not Boaty McBoatface,,,First Worldcon,8/5/2016 15:19:33,notboatymcboatface@fake.com,North,Pole,Algeria,Not,Face,189
-Romana,,,First Worldcon,8/5/2016 15:25:49,Timelady@gallifreymail.com,Capitol City,Prydonia,Gallifrey,Romanadvoratralunda,,190
-Potato McLoving,,,Child,8/5/2016 15:27:20,respectthis@beemail.com,The mythical city of Washington,California?,Germany,Hoffnung,Ui!,191
-Janice Montgomery,,,Adult,8/5/2016 15:28:41,janielanie@live.com,Ho Chi Minh City,,Vietnam,Janice,,
-Morty Yelnats,,,First Worldcon,8/5/2016 15:30:07,Mortyels@notarealemailserver.co,The Moon,,,Morty,Yelnats,192
-Chet Flash,,,Kid-in-tow,8/5/2016 15:32:57,chetflash@charter.net,the moon,the moon,the moon,Chet,Flash,193
-Kate Malcolm,,,Adult,8/5/2016 15:33:16,midevilbabe@btinternet.co.uk,Richmond-on-Thames,London ,United Kingdom,,,
-Ember,Supporter,8/5/2016 15:35:30,,,Aydenalendil071@aim.com,Boise,Idaho,USA ,Jane,Doe ,
-Abso Lutien,,,First Worldcon,8/5/2016 15:37:17,ALutien@no.com,Auckland,,New Zealand,Absol,Lution,
-Mrowing Mrower,,,First Worldcon,8/5/2016 15:48:43,mmwatchasay@gmail.com,Bowster,California,USA,Mrowing,Mrower,
-Robert'); DROP TABLE members;--,,,First Worldcon,8/5/2016 15:52:30,Bobby@fake.com,Oz,Oz,Over the rainbow,Bobby,Tables,194
-MCsketti,,,Youth,8/5/2016 15:55:58,THisLOveHastaakkenCONtrolOFme@homtail.comb,A cardboard box,A larger cardboard box,A fucking massive cardboard box,Borg,Magorg,195
-Zuppa di Day,,,Kid-in-tow,8/5/2016 15:59:53,Zdd@imaginaryrealms.net,Saskatchewan,Wherever Saskatchewan is...,Kyrgystan,Zup,Day,196
-Meow Meowface,,,Adult,8/5/2016 16:02:44,meow@catsville.org,Purrfect Peeeeace,Catsholme,Cat-Holica,Meow,Meowface,197
-Marian,,,Adult,8/5/2016 16:03:04,Me.com,Lothering,N/A,Gone,Marian,,198
-Akhal-Teke,,,First Worldcon,8/5/2016 16:14:48,akhal@teke.com,Portland,Maine,USA,Akhal,Teke,199
-Delta,,,First Worldcon,8/5/2016 16:15:12,Delta@projectfreelancer.mil,New Luxor,Eridanus II,Outer Colonies,Delta,Church,200
-Ragnell Szeto,,,Youth,8/5/2016 16:18:54,Rszeto1987@webmail.com,Cairo,Illinois,USA,Ragnell,Smith,201
-Lala Mc'Sparkle,,,Adult,8/5/2016 16:20:48,Ozonlimes@esther.org,Gibbsonville,IT,USA,,,
-Maya Wiener,,,Child,8/5/2016 16:22:43,,,,,,,202
-Charlotte the Spider,,,First Worldcon,8/5/2016 16:24:55,web@parlor.org,Old Farmstead,Towney Town,Old Timey America,Charlotte,Spider,203
-Impala67,,,First Worldcon,8/5/2016 16:33:08,fake@fake-email.com,Lawrence,Kansas,USA,Dean,Winchester,
-Jane Elisabeth Carson,,,First Worldcon,8/5/2016 16:34:17,jec@gmail.ca,Arva,Ontario,Canada,Jane,Carson,
-Remin Baskavits,,,Adult,8/5/2016 16:34:53,Rbakavits@gmail.com,Stonyvale,WI,United States,Remin,B.,204
-Tracy C. Tillman,,,First Worldcon,8/5/2016 16:43:28,TracyCTillman@armyspy.com,Tempe,Arizona,USA,Tracy,Tillman,205
-Anaander Mianaai,,,Adult,8/5/2016 16:44:10,miannaaia@radch.gov,The Radch,Radch,Radch,Anaander,Mianaai,206
-Anders And,,,Adult,8/5/2016 16:47:34,andersand@andersandmail.andeby,Andeby,Andeby,Andeby,Anders,And ,207
-Highest Noon,,,Child,8/5/2016 16:48:48,Hanzo@McCree.bark,Yiffton,West Yaoi,Kinkistan,Tolta,Sirus,
-Larry Butz,,,First Worldcon,8/5/2016 16:49:16,l.butz@fake.com,Cowton,Oregon,USA,Larry,B.,
-David Washington,,,Adult,8/5/2016 16:52:47,agentwashington@projectfreelancer.com,Seattle,Washington ,USA,David,Washington,208
-C. Niall D. Mentia,,,Kid-in-tow,8/5/2016 16:57:56,donald.trump@yiffyiff.constantly,Uranus,NSFW,anyGerm,Eyema,Faygit,209
-Michael J. Caboose,,,Kid-in-tow,8/5/2016 17:03:06,Churchismybestfriend@basebook.com,The moon,Still the moon,Earth,Michael,Caboose,210
-Count Petyr Bezukhov,,,Adult,8/5/2016 17:04:13,Napoleancanbiteme@gmail.com,Moscow,Russia,Russia,Pierre,Bezukhov,
-Marie Wolfe,,,Adult,8/5/2016 17:15:09,mizzwolfe@fakey.com,Kitchissippi,Iowa,USA,Marie,Wolfe,
-Brontus McMiller,,,First Worldcon,8/5/2016 17:24:32,jackedupsoupedup@hotmail.com,Dubai,Dubai,,,,211
-W.H.Oami,,,Adult,8/5/2016 17:25:55,Falsified@faaified.com,Yorick,Yorickshire,Yorickson,Q,Jepson,212
-Amanda Hugginkiss,,,First Worldcon,8/5/2016 17:26:54,ahk@example.com,Fauxington,NW,US,Amanda,,213
-Sherlock Beeblebrox,,,Youth,8/5/2016 17:27:09,supercalifragilistic@aol.com,Ankh-Morpork,Ankh-Morpork,Discworld,Albert,Hall,
-Hugo Second,,,First Worldcon,8/5/2016 17:28:39,h2nd@overcliffe.net,Sun City,Wiltshire,UK,Hugo,Second,214
-Lauren Ipsum,,,Kid-in-tow,8/5/2016 17:30:17,Lauren.Ipsum@Dolor.sit,221B Baker Street,PA,Camelot,Lauren,Ipsum,215
-Jane Doe,,,Kid-in-tow,8/5/2016 17:32:03,janedoes@gmail.com,Nowhere,Oregon,USA,Jane,Doe,216
-James T. Kirk,,,First Worldcon,8/5/2016 17:32:06,j.t.kirk@enterprise.starfleet,Cornfed,Iowa,The Final Frontier,Captain,Kirk,
-Arthur Pendragon,Supporter,8/5/2016 17:33:37,,,TheOnceandFutureKing@camelot.co.uk,Avalon,Wales,Camelot,Gwydion,Ectorson,217
-Hiccup Horrendous Haddock III,,,Kid-in-tow,8/5/2016 17:34:23,Hiccup@berk.bk,Berk,Berk,the Barbarous Archipelago,Hiccup,Stoicksson,
-Spock,,,Adult,8/5/2016 17:35:32,spock@enterprise.starfleet,Vulcan,T'Khar,Vulcan,Spock,You couldn't pronounce it,
-Peanut Disarien,,,First Worldcon,8/5/2016 17:36:41,butternut@pmail.com,athabaski,whashinigan,matteri,Pea,Disi,218
-Jack Bruce,,,First Worldcon,8/5/2016 17:40:14,THIS IS A FAKE EMAIL,London,,England,Jack,Bruce,219
-Ms. Tiggie Terrible,,,First Worldcon,8/5/2016 17:49:36,donotusethis@gmail.com,Ridgefield Park,NJ,USA,Ti,Terrible,220
-Merlin Emrys,Supporter,8/5/2016 17:53:57,,,"Arthur's quarters, the Citadel",The Citadel,Camelot,Camelot,MERlin,Emrys,221
-John Watson,,,Adult,8/5/2016 17:55:23,Johnwatson@memail.co.uk,London,Central,UK,John,Watson,
-Doctor Who,,,Adult,8/5/2016 17:56:17,thedoctor@tardis.gallifrey,all of them,all of them,all of them,The Doctor,"No, just ""The Doctor""",
-Zaphod Beeblebrox III,,,First Worldcon,8/5/2016 18:02:51,zaphod@yowza.com,Mandalor,,,Zaph,Baby,222
-Budworth Barclay,,,Kid-in-tow,8/5/2016 18:16:08,,Albany,New York,Finland,Bud,Jefferson,
-Brooke Wyles,,,Adult,8/5/2016 18:19:42,bwyles@email.com,Los Angeles,California,USA,Brooke,Wyles,
-Elodie Sinclair,,,First Worldcon,8/5/2016 18:21:06,ElodieEss@Hotmail.com,Montreal,Quebec,Canada,Elodie,Sinclair,223
-Eleven,,,Child,8/5/2016 18:22:34,SecretlyYoda@gmail.com,What do you mean,This isn't Maine,United States,Eleven,,
-I-have-no-mouth-and-i-must-scream Connors,,,Kid-in-tow,8/5/2016 18:23:33,yesjustlikethesouldevouringattheendoftheworld@planeteatersanonymous.whatno,Room 234876B,Tafanda Bay,Ithor,I-have-no-mouth-and-i-must-scream,Connors,224
-Emily Campbell,,,First Worldcon,8/5/2016 18:35:36,ecampbell@hogwarts.com,Kiel,Schleswig-Holstein,Germany,Emily,Kampbell,225
-Eloise Eloquent,,,Adult,8/5/2016 18:43:36,Eeee@email.com,Nebraska,Nova Scotia,Deutschland,Esiole,Tneuqole,226
-Spock Smith,,,First Worldcon,8/5/2016 18:58:48,spock@enterprise.com,Shikar,Star City,Vulcan,Spock,Smith,
-SADIE HALFTALL,,,Kid-in-tow,8/5/2016 19:00:03,Sadie@dragonmail.com,The lair of the dragons,What part of the lair of the dragons didn't you get?,Wherever the lair of the dragons is.,Sadie,Brass,
-Sassy T. Cat,,,First Worldcon,8/5/2016 19:02:23,furball@catnip.com,Farmville 2,Moosylvania,US,Sassy,Cat,227
-Bendydoink Catsinpants,,,Kid-in-tow,8/5/2016 19:02:49,bcatsinpants@yourchimney.org,Abu Dhabi,The World,The Milky Way,Ben,Cats,
-Melody Goldstein,,,Adult,8/5/2016 19:03:00,sukadogdik@aol.com,Kansas City,Nebraska,Unites States,Melody,Goldstein,
-Sifu Hotman,,,First Worldcon,8/5/2016 19:04:45,sifu_hotman@fakemail.com,Ba Sing Se,Earth Kingdom,Earth Kingdom,Sifu,Hotman,228
-Samuel,,,Adult,8/5/2016 19:05:01,samuel@noneofyourbusiness.com,Chicago,Illinois,Usa,Samuel,Samuelson,229
-Bobby Newport,,,Adult,8/5/2016 19:10:29,hasneverhadarealjob@inhislife.com,Pawnee,Indiana,US,Bobby,Newport,230
-Taco McBell,,,Adult,8/5/2016 19:21:16,goose@gaggle.com,,,,Taco,McBell,231
-Donald Doodyhead,,,First Worldcon,8/5/2016 19:25:03,donalddoodyhead@msn.com,NYC,NY,USA,Donnie,,
-Edna Edelweiss ,,,Adult,8/5/2016 19:29:12,floraflower09@gmail.com,Margaritaville ,Florida,USA,Daisy,,232
-Mat Cauthon,,,First Worldcon,8/5/2016 19:29:50,Luckypips7@gmail.com,Emond's Field,PA,USA,Knotai,Cauthon,
-Ogdor,,,Kid-in-tow,8/5/2016 19:34:41,What?,North York,South York,New Carolina,The Great,And Powerful,233
-OohAah Cantona,,,Youth,8/5/2016 19:37:23,canolisarealright@intaliano.com,Piza,,Italy,OohAah,Cantona,
-Ashton Howerton,,,Child,8/5/2016 19:52:19,Ashho@gmail.com,Lilith,New York,America,Ashton,Howerton,
-"Gorblaxis Slaglon, King of Gamma VII",,,Kid-in-tow,8/5/2016 19:52:32,EarthConquerer@gorblaxiaplaza.gov,New York City (Soon to be renamed Gorblaxia II),New York,United States,Doom,Bringer,234
-Chet Gladstones,,,Adult,8/5/2016 20:00:45,frutieprincessbubblegum@gmail.com,Hell,Michigan,USA,Charles,Happypebbles,235
-Ryba McNuggins,,,Kid-in-tow,8/5/2016 20:06:16,Squishly@zorg.com,La Luna,Ourkansas,Canana,Georgous,Strigling,
-Izzy Ruto,,,First Worldcon,8/5/2016 20:28:14,izzy.ruto@gmail.com,Mobile,Alabama,United States,Isabella,Ruto,
-Margot Empress Of Destruction,,,First Worldcon,8/5/2016 21:08:15,12345@fakeemal.cob,Iacon,Manganese,Cybertron,Jane,Doe,
-Dave Strider,,,Youth,8/5/2016 21:30:20,turntechgodhead@cool.com,not the fucking meteor anymore,idek anymore,the current universe,Dave,Strider,236
-Alex Colin Stewart,,,Youth,8/5/2016 21:32:30,,San Fransisco,California,America,Alec,Stewart,237
-Kathryn Janeway,,,Adult,8/5/2016 21:36:02,kathryn.janeway@voyager.mail,Voyager,Delta Quadrant,Space,Kathryn,Janeway,
-Titty Malasyia,Supporter,8/5/2016 21:37:59,,,orphan.black@gmail.com,Scarborough ,Toronto,Canada,Titty,Malasyia ,
-👽👭😍🌌,,,Youth,8/5/2016 21:43:13,👽👭😍🌌,👽👭😍🌌,👽👭 😍 🌌 ,👽 👭 😍 🌌 ,👽 👭 😍 🌌 ,👽 👭 😍 🌌 ,238
-Dairine Callahan,,,Youth,8/5/2016 21:45:59,dari@worldsend.co,Long Island,NY,USA,Dari,Callahan,239
-Разбойник Бармалей,,,Adult,8/5/2016 21:57:02,barmaley@mail.chu,Джунгли,Лимпопо,Занзибар,Бармалей,Разбойник,
-Kalessin Prrrrrer,,,First Worldcon,8/5/2016 22:10:10,kitten@mau.pr,Kastrop-Rauxel,NRW,Germany,Kali,Cat,240
-Gilbert Forthright,,,Child,8/5/2016 22:22:27,Gilbertthegrape@communistconspiracy.com,Buenos Aires,,Sokovia,Hortense,Puddlington,241
-Lucia Marino,,,Adult,8/5/2016 22:35:31,lucia.marino@paladino.es,Charouse,Villanova Ile,Vodacce,Lucia,Marino,242
-Jubilation Lee,,,First Worldcon,8/5/2016 22:40:57,jubilee@xavier.edu,New York City,NY,USA,,,243
-El Fake-o Name-o,,,First Worldcon,8/5/2016 23:20:17,1234 Any Street,Hometown,DC,USA,Anonny O,El Name-o (Bingo),244
-Rose Marian Day,,,First Worldcon,8/5/2016 23:20:55,rmday@gmail.com,Exeter,New Hampshire,United States of America,Rose,Day,
-❆,Supporter,8/5/2016 23:24:10,,,a@b,Espero Urbo,Ĉi tie,Esperantolando,☜☝☞☟,,245
-Meranna di Cantos,,,First Worldcon,8/5/2016 23:46:43,meranna_di_cantos@mileth.net,Mileth,Rucesion,Temuair,Meranna,di Cantos,246
-Reginald Sinclair,,,Adult,8/5/2016 23:56:13,reginald_+finland@catbus.co.uk,Manchester,Manchester,England,Reggie,Spectrum,247
-Txhmamiqat atarsalkamoxh,,,First Worldcon,8/6/2016 0:04:31,pxhatmar@kusaq.tx,Dallas,TX,United States,Itiraq,,
-Hayden Kensington,,,First Worldcon,8/6/2016 0:16:36,mail@fakeemail.com,Broomfield,Wisconsin,United States of Hilarity,Kendra,Smith,
-Isgebind,,,Kid-in-tow,8/6/2016 0:17:25,indolent@me.com,Groovytown,RI,USA,Meg,Murray,248
-Not Batman Obviously ,Supporter,8/6/2016 0:35:34,,,Nbo@elsewhere.com,The Base,The Moon,Space,Not,Obviously ,
-Kethrys,,,Kid-in-tow,8/6/2016 0:50:30,Kehthxs@hyosmil.com,Sparta,Alberta,Canada ,Josie,McDonald,249
-Stella Kui,,,Youth,8/6/2016 1:05:32,fornlets1950@jourrapide.com,"Los Angeles, California",California,United States,,,
-Rowan Sunchild,,,Adult,8/6/2016 1:18:18,albacore@deepsea.net,Golden Lake,Yukon Territory,Canada,Jo,Billingsworth,250
-Lulu,,,Child,8/6/2016 1:26:11,luluandromedadestroyerof@worlds.com,The moon,Solar System,Milky Way,THE lulu,None of your beeswax ,
-Peri,,,Kid-in-tow,8/6/2016 1:31:12,Peri.dot@gmail.com,Pflugerville,Texas,UAE,Peri,Dot,
-Donglord McSucc,Supporter,8/6/2016 1:45:53,,,albanybaster@mrrrrrrrrr.com,The Moon,Down South,This period -->.,JOHNNNNNNN ,cena.,251
-Ekatarin Vorkosigan,,,Kid-in-tow,8/6/2016 2:03:22,gardencat@hassadar.edi,Vorbarr Sultana,Vorkosigan ,Barrayaran Empire,Ekaterin,Vorkosigan,
-Bob,,,First Worldcon,8/6/2016 2:03:34,boop@beep.com,Vorkosigan,WY,Andorra,Frederick,Kruger,252
-Sara martignone,,,Youth,8/6/2016 2:46:10,sara.m.90@gmail.com,Jujuy,Jujuy,Argentina,Sara,Martignone,
-Kade Kennedy,,,Adult,8/6/2016 3:03:23,Rikroll@otherworlds.com,Riverside,Mo,USA,Georg,Handel,
-Gerry James,,,Youth,8/6/2016 3:21:45,Gerryjames4678425098813@gmail.com,San Francisco ,California ,United States,Gerry,James,253
-Supreme Leader Kim Jong Un,,,First Worldcon,8/6/2016 3:26:31,kimjongun@northkorea.com,Pyongyang,,North Korea,Kimmy,,254
-Wilhelmina Iggleswoop,,,Adult,8/6/2016 3:27:50,WI@london.ig,Uberchester-on-the-Slope,Undershire,UK,Willie,Iggleswoop,
-Lemons McLemons,,,First Worldcon,8/6/2016 3:52:06,lemons@lemons.lemons,Lacus Somniorum,Isternes,The Moon,Lemons,Ransom,255
-Peppermint Bunny,,,Adult,8/6/2016 4:11:54,pepperbun@hutch.net,Carrottown,New Burrow,Fursylvania,Pepper,Bun,
-Pack Hunt,,,Kid-in-tow,8/6/2016 4:15:56,packsaplenty@imgonnahowllots.wolf,Gruul,Ravnica,Dominaria,Squanchum,Hunt,256
-Adán Najera,,,Kid-in-tow,8/6/2016 4:17:32,grizzlycudlebear@yahoo.com,Bear Town,Ursus Land,Bear Den,Dan,Naj,257
-Garnet McBadass,,,Adult,8/6/2016 4:26:42,butterycupcakes@nomail.com,Jupiter,Norway,Gemworld,Meredith,Snailslayer,258
-Alfred E. Neuman,,,Adult,8/6/2016 4:40:46,Yahoo@mad.com,Brooklyn,New York,USA ,Alfie,Neuman,259
-One Entire Succ,,,Youth,8/6/2016 4:45:24,dat_boi@succ.com,,,Succland,,,
-Cider Ilohas,,,First Worldcon,8/6/2016 4:51:33,tennen@brop.com,Boring,Oregon,USA,,,
-Pepe Scoober,,,Child,8/6/2016 5:01:57,ohshit@scooby.me,Gaytown,Boom,Nanaland,Doofus,Boofer,
-Frau Doktor Worblehat,,,First Worldcon,8/6/2016 5:13:22,fraudoktor@unseenuniversity.edu,Ankh-Morpork,The Left Side,Diskworld,Frau,Worblehat,260
-Ariane Chodkow,,,First Worldcon,8/6/2016 5:26:33,achod@gmoil.com,Woodrowburg,CA,US,Ariane,Chodkow,
-Duke Hardcastle,,,First Worldcon,8/6/2016 5:31:07,hcastle@msn.com,Waukesha,WI,USA,Duke,Castle,
-Annabelle Dierett,,,First Worldcon,8/6/2016 5:51:26,annabelle@terran.edu,Laguna Garden,Mainland,Taeat,Annabelle,Dierett,261
-Aarti Skywalker,,,Adult,8/6/2016 6:45:12,polgarathesorceress@gmail.com,Tokyo,Zurich,Australia,Ellariayn,Weatherwax,
-Amy Salmonhead,,,Kid-in-tow,8/6/2016 7:19:06,iamnotedible@gmail.com,Santa's Village,Alabama,United States,Amy,Salmonhead,
-Maria Turnbull,,,First Worldcon,8/6/2016 7:27:33,m4ria.turnbull23@gmail.com,Auckland,,New Zealand,Maria,Turnbull,262
-Jayden Starstorm,,,First Worldcon,8/6/2016 8:28:57,jaydensthebestalwaysforever@myemail.com,Pittsburgh,Jersey,Somerset,Starstorm,Jayden,263
-Julia Belvedere,,,First Worldcon,8/6/2016 8:36:52,,Topeka,Kansas,United States,,,264
-Clarice Starling,,,First Worldcon,8/6/2016 8:51:37,clarice@fakeemail.com,nowhere,new narnia,further up and further in,Callie,Star,265
-Tony Stark,,,Adult,8/6/2016 10:31:26,Stark@stark.com,Malibu,California,Usa,Tony,Stark,
-Pete Zahut,,,First Worldcon,8/6/2016 18:52:22,petezahut@fakeaddress.suk,Barsoom,Hy,Madagascar,Pete,Zahut,
-Rick Jones,Supporter,8/6/2016 19:09:08,,,rickjones@sidekicks.com,Scarsdale,Arizona,USA,The,Whisperer,
-Temeraire,,,First Worldcon,8/6/2016 19:14:36,temeraire@aerialcorps.mod.uk,Loch Laggan (it rhymes with my species),,Scotland,,,
-BoomShakaLaka,Supporter,8/6/2016 19:30:20,,,bigbang4eva@topsmassivebulge.woah,Your Face,Fantastic Baby,Random park bench,Boom,ShakaLaka,
-Nimps,Supporter,8/6/2016 19:36:07,,,niimps@silverline.net,Milwaukee,Nebraska,Georgia,Temperance,Cuervo,266
-Esteban Morolonion,,,Child,8/6/2016 19:59:33,kjsadf@lskdjfa,Kingdom in the Mists,Windermere,Wild West,King Gilead,Windermere,
-Eblis O'Shaunessy,,,Adult,8/6/2016 20:09:53,eblis@aol.com,Hades,Elsewhere,Mootopia,Ebbles,Oshun,
-Fairest and Fallen,,,First Worldcon,8/6/2016 22:20:28,theothersideoftheuniverse@tptb.wizardry ,NYC Alternate Universe,NY,Timeheart,Lone,Power,267
-Arcflash Watts,,,Youth,8/6/2016 23:10:26,arcflash@melancholyhill.talent,New York,New York,United States of America,Arcflash,,268
-Memory Greycat,,,First Worldcon,8/6/2016 23:27:55,memory@thegrey.cat,Meh,Maune,United Siamese Adults,Grey,Cat,269
-Dude McPherseon-Plantaganet,,,Adult,8/6/2016 23:37:17,mcpherse@btu.edu,Lodgepolis,Montana,United States of AMERICA ,Dude ,Lodgepolitian,270
-Alice The Horse,,,First Worldcon,8/6/2016 23:42:25,alicethehorse@yandex.com,Steveston,Massachusetts,U.S.,Alice,Offbrand Amish,
-Sally-May,Supporter,8/6/2016 23:48:26,,,Salliemae@shady.gov,Newark,Delaware,U.S.A.,Sallie,Banker,271
-Adam Young,,,Youth,8/6/2016 23:55:16,adamyoung@stopmessingaroundinpeople'slives.net,Lower Tadfield,Oxfordshire,Unseceded Britain,Adam,Young,
-Declan Dublin,,,Adult,8/7/2016 0:01:32,PorkyPig69er@hotdawg.du,Helsinki,Baconshire,Un-united Kingdom,I Really Like the Letter,WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW,272
-Fake Bill,Supporter,8/7/2016 0:22:23,,,disposable+tag@fastmail.fm,Croton-on-Hudson,NY,USA,Still Fake,Nielsen Hayden,
-Marsh Skatekey,,,Kid-in-tow,8/7/2016 0:27:49,i'llrootfortheoilersifiwantgetoffmycase@hotmail.com,Rainy River Dist.,Ontario,Canada,Shep,The Ex-Shepherd,273
-Spodo Komodo,,,First Worldcon,8/7/2016 1:07:41,s.komodo@goat.com,Limerick,,Eire,Spodo,Komodo,
-Superfly McDr,,,Adult,8/7/2016 3:21:25,pinthis@hotstuff.net,Normal,IL,USA,Super,McDr,274
-Meadow Lark,,,First Worldcon,8/7/2016 3:38:32,Mlark@umail.com uwu,BOSS TOWN (ﾉ≧∇≦)ﾉ ﾐ ┸━┸,Massachussetts,U!S!A!,Meadow,,
-Bella Fuga,,,Adult,8/7/2016 4:56:41,genericemail@yahoo.com,Boring,Oregon,USA,,,
-Jimmy); DROP TABLE Members; --,,,First Worldcon,8/7/2016 5:25:31,jimmy@abl.es,Oxford,Oxfordshire,Earth,jimmy,tables,275
-Abby Stonebender,,,First Worldcon,8/7/2016 7:06:54,beauregard21@hotmail.com,Toledo,Ohio,USA,Abby,Stonebender,
-Helena Morgan,,,Adult,8/7/2016 8:37:05,this.is.legit.fake+extrastuff@example.com,Omelas,Uncertainty,Earth,Helena,,
-Swagamoto,,,First Worldcon,8/7/2016 8:39:04,swagamoto@hotmail.com,Swagville,Swag County,Swaglandia,Swagamoto,Swagamoto,276
-Sauce,,,Adult,8/7/2016 8:43:47,sauce_uke@gmail.com,Konohagakure,Konohagakure,Hi no Kuni,Sasuke,Uchiha,277
-L,,,Kid-in-tow,8/7/2016 8:46:36,lllowlight@hotmail.com,Secret,N/A,SECRET,L,L,278
-Harry BWL Potter,Supporter,8/7/2016 8:51:13,,,treacletreacletreacletart@gmail.com,NOT Surrey,,The No Longer United Kingdom of Great Britain and Northern Ireland (Thanks a Million Brexit),Harry,Potter,279
-Speshul,,,Youth,8/7/2016 8:53:50,speshulsnowflake@msn.com,Tumblrton,New Tumblr,Tumblria,Speshul,Snowflake,280
-Yaoirox,,,Adult,8/7/2016 8:55:49,yaoirocrokroxomgz@gmail.com,Yaoiiiiiiiiiii,Roxxxxxxx,Yaoiroxland,Yaoifan,Yaoirox,
-Ash Ketchup,Supporter,8/7/2016 8:58:09,,,pokemongoz@gmail.com,Pallet Town,Kanto,Pokeworld,Ash,Ketchup,281
-Åäö ÅåÄäÖö,,,Child,8/7/2016 10:09:33,åäö@öö.åå,Åland,,Öland,Å,Ö,282
-"de Havílland, John",Supporter,8/7/2016 10:12:38,,,jdh@jdh.is.not,Lüxembørg,,Ærland,John,de Havílland,
-James Arthur Saville,,,Adult,8/7/2016 12:17:22,SirJimmy@saville.org.uk,Brummieland,Nonceville,UK,Sir Jimmy,Saville,
-hnreaz vtr68iuvc,,,First Worldcon,8/7/2016 14:43:21,hnu5ipq-bmrie90+,ohio,ohio,ohio,bcftr,cty,
-Ture Storm,,,First Worldcon,8/7/2016 15:04:25,turestorm@fandom.org,Stockholm,,Sweden,Ture,Storm,283
-"Catherine the Gray of House Pendragon, De-feeter of Buggies and Lord of the Underbed",,,First Worldcon,8/7/2016 15:53:11,CTG@fakemail.com,Underbed,Pennsylvania,USA,Cat,Pendragon,
-Laurel Kay Pendragon,,,First Worldcon,8/7/2016 16:03:45,onetwothree@bob.com,Emerald City,PA,USA,Kay,Pendragon,
-Dr. John Smith,,,First Worldcon,8/7/2016 21:32:31,Doctor@tardis.sp.mil,The Barn,The Citadel,Gallifrey,John,Smith,284
-David Bowie,Supporter,8/7/2016 22:44:27,,,Spaceman@wtf.fashion,Brixton,London,England,Ziggy,Stardust,
- —,,,Child,8/8/2016 5:54:29, , , , , , ,
-        @,,,Child,8/8/2016 5:55:33,,,,,,,285
-Jack Rabbit,,,Kid-in-tow,8/8/2016 6:43:25,secretylajackalope@horns.net,Kansas City,MO,USA,Jack,Rabbit,286
-Taliesin Locke,,,First Worldcon,8/8/2016 9:56:56,taltale92@gmail.com,Vedado,Havana,Cuba,Tali,Locke,
-Radomir Meleg,,,Adult,8/8/2016 16:39:31,radma@hum-szeged.hu,Szeged,,Hungary,Radomir,Meleg,287
-Loránd Eötvös,,,First Worldcon,8/8/2016 17:06:59,derboss@eeltee.hu,Budapest,,Hungary,Loránd,The Man,
-Honesty Masters ,,,Child,8/8/2016 17:29:13,kelpietickler@hotmail.com,Salt Lake City,Utah,USA,Sillimos,,
-Richard Tuukc,Supporter,8/8/2016 17:53:03,,,,,AK,USA,Rick,,288
-Elena Shvarts,,,Adult,8/8/2016 18:03:54,,St. Petersburg,Leningradskaya Oblast',Russian Federarion,Lena,Shvarts,289
-Jolana Popović,Supporter,8/8/2016 18:36:32,,,jolana.popovic@zemunjezakon.rs,Beograd,,Serbia,Jo,Popović,
-Lindsay James,,,First Worldcon,8/8/2016 21:42:34,mcpoodle.doodle@aol.com,Philadelphia,PA,United States,Lindsay,James,290
-drop table;,,,Adult,8/8/2016 22:03:31,drop table;,drop table;,drop table;,drop table;,drop table;,drop table;,291
-James Bond,,,Adult,8/9/2016 5:55:55,007@mi6.gov.uk,classified,classified,England,James,Bond,
-Slatribartfast albus hinikin iii,,,First Worldcon,8/9/2016 8:10:11,embaressingusername25@angelfire2.com,Norway,ohio,america of the north,bart,hinikin,292
-Slipnotika Kornilia Edgelord,,,Youth,8/9/2016 8:19:25,Thereisnonemoreedge@razor.com,blackwall ,edgess,Noirvania,Knottikorn,Edgelord,
-Person Unusual,,,First Worldcon,8/9/2016 18:23:55,person@person.org,Atlanta,KS,USA,Person,Person,293
-Claire Dale,,,First Worldcon,8/10/2016 1:11:51,clairedale92@yahoo.com,Cedar town ,Georgia ,America,Claire,Dale,294
-"Ponsonby Britt, O.B.E.",,,First Worldcon,8/10/2016 9:28:42,ponsonby@britt.obe,Mafeking,,Transvaal Colony,Ponsonby,Britt,295
-Horatio Xavier Taylor-Smith,,,Adult,8/10/2016 17:58:23,h.xavier.taylor-smith@gmail.com,Juarez del Norte,Texas,USA,Xavier,Taylor-Smith,
-Geo-Rge Jetson,,,First Worldcon,8/13/2016 1:18:11,123@CBSOUTDOOR.com,St Louis,MO,USA,Geo-Rge,Jeston,
-Julian Nebogipfel,,,Adult,8/13/2016 23:49:29,alpha.ralpha@boule.com,Deep Space,Gilead,Fandom,Julian,Julian,
-Ash Ketchum,,,Youth,8/14/2016 7:56:13,catchemall@pallettown.kn,Pallet Town,Kanto,Kanto,Ash,Ketchum,296
-Kalani The Parrot,,,First Worldcon,8/15/2016 1:27:32,,Alexandria,,Egypt,Kalani,Kalani,
-Ginger Johnson,,,First Worldcon,8/15/2016 1:35:11,pematson@yahoo.com,Rochester,NY,US,Snaps,Johnson,297
-Sally Park,Supporter,8/15/2016 1:37:32,,,pematson@yahoo.com,San Francisco,Calif.,USA,Sally,Park,
-Tilda Gelhorn,,,First Worldcon,8/15/2016 1:41:29,pematson@yahoo.com,,,,Tilda,Gelhorn,298
-Princess Ariadne,,,Youth,8/15/2016 1:45:49,,Knossos,Crete,Crete,Princess,Ariadne,299
-Jill Highsmith,Supporter,8/15/2016 1:52:09,,,jhighsmith@nationalparks.uk.gov,Windermere,Cumbria,England,Jill,Highsmith,
-Robin Williamson,,,First Worldcon,8/15/2016 4:08:43,palmtrees@grimace.com,Salem,Massachusetts,United States,Robin,Williamson,300
-Anna,,,Adult,8/15/2016 19:15:48,Please.best@yahoo.org,East Jordan,MI,America,Mickey,I,301
-Mijn echte Foute Naam,,,First Worldcon,8/17/2016 11:53:20,Ikke@amsterdam.nl,Amsterdam,Noord Holland ,The Netherlands,I ,Amsterdam,302
-Tellu Tyllönen,,,Adult,8/20/2016 11:52:18,tellu.tyllonen@jossain.com,Kemijärvi,,Finland,Tellu,Tyllönen,
-Ta-Neisha Wu,,,Kid-in-tow,8/23/2016 7:10:59,taneisha@gmail.comm,Newark,NJ,USA,Ta-Neisha,,
-Alys Moggie Catnip,,,Kid-in-tow,8/24/2016 3:13:49,AMog@FakeMail.com,Purrsepolis,Fursylvania,Catatonia,Alys Moggie,Catnip,
-Arabella Ashby,,,First Worldcon,8/24/2016 3:34:00,A.Ashby@Diana.MarsTrading.Com,Woodthrush Woods,Fort Augusta,Mars,Arabella,Ashby,
-Keeler Altair,,,First Worldcon,8/26/2016 1:15:01,k.altair@battle.ship,None,None,Alternia,,,303
-Anastasia Sÿms,,,First Worldcon,8/29/2016 4:15:38,011110@jeep.com,Holland,Michigan,US,FanGrrrl,,304
-Meep Newton,Supporter,8/29/2016 4:17:25,,,Meep@gmail.com,Michigan City,IN,US,Meep,Newton,
-Frisk Dreamurr,,,Youth,9/13/2016 4:22:14,IHaveALotOfParents@Underground.Net,The Ruins,The Surface,The Underground,Frisk,D.,
-Shelby Bradbury,Supporter,9/13/2016 4:26:30,,,GracefulAce@Tailer.com,Pureshed City,Millington,England,Shaun,B.,305
-Craig Xerxes Retsnimde,,,Kid-in-tow,9/14/2016 3:20:55,YaBoy@Deeznuts.org,Jerville,Smufton-on-the-barrows,Elgarn,Huilky,Jervsondottirson,306
-Derf Relmits,,,First Worldcon,9/16/2016 4:14:11,fiddle-dee-dee@tara.manse,Atlantis,Santorini,Crete,Wheres,Waldo,307
-Fizzgig von Fuzzelbutt,,,Adult,9/25/2016 2:21:16,Noone@loopback.edu,Rlyeh,Botali,Hell,Fizzgig,Von Fuzzelbutt,308
-Marimekko Mirjala,,,Youth,9/25/2016 17:51:51,marimiri@meks.fi,Urjakkala,Millinen,Magalo,,,
-Fairy Land,,,First Worldcon,9/26/2016 19:04:13,fl@unseeliecourt.org,,,underground probably,,,309
-Fizzleborg Humperding,,,Kid-in-tow,10/6/2016 22:56:11,hump@ding.lol,Krachmannlachens,Hinterdingen - Legenscheid,Banalachen,,,310
-Falkrunn Ungart,,,Kid-in-tow,1/17/2017 10:18:26,intricatemasonryyay@ymail.com,Waren,Kein,Denmark,Falkrunn,Ungart,
+legal_name,supporter,supporter_date,upgrade,upgrade_date,email,city,state,country,public_first_name,public_last_name,paper_pubs_id,postcode,address,badge_text
+Samuel Vimes,Supporter,8/4/2016 12:29:02,,,s.vimes@gmial.ocm,Ankh-Morpork,,The Disc,,,1,,,
+Factual Blob,,,First Worldcon,8/4/2016 12:30:50,fblog@fblobsblog.com,Fact City,Data Central,Blobitania,Fake (Factual),Blob,,,,
+Æthelwine B. Clobberfeld,,,First Worldcon,8/4/2016 12:31:26,abc@cba.nr,Yaren,Yaren District,Nauru,Æthelwine,Clobberfeld,2,,,
+Polly Amorous,,,Adult,8/4/2016 12:31:37,Allthelove@manymoresomuch.fi,Helsinki,Helsinki,Finland,Polly,Amorous,3,,,
+Jorma Mörönen,,,Adult,8/4/2016 12:32:25,jorma@moronen.com,Paris,,France,,,,,,
+Lost At Void,,,First Worldcon,8/4/2016 12:32:42,lost@void.net,Emerald City,,,Lost,Void,,,,
+Hoy Ping Pong,,,Adult,8/4/2016 12:33:11,hpp@tucker.net,Bloomington,IL,USA,Hoy Ping,Pong,,,,
+Rodrigo Almodovar,,,Adult,8/4/2016 12:34:32,Ralmo@mwahaha.boo,Acapulco,Mexico,Mexico,Roro,Almi,4,,,
+Dr. Ackula,,,Adult,8/4/2016 12:34:52,Forrest@ackerman.per,Hollywood,CA,USA,Dr.,Ackula,5,,,
+TreeFree Forest Sprite,Supporter,8/4/2016 12:35:21,,,SaplingPower@enddeforestationnow.net,Orick,California,United State,TreeFree,Forest Sprite,,,,
+Donald Duck,,,Adult,8/4/2016 12:36:33,donald@duck.duck,Duckburg,Calisota,,Donald,Duck,,,,
+Thomas Fool,,,First Worldcon,8/4/2016 12:37:13,thomas.fool@hell.gov,Houska,,Hell,Thomas,Fool,,,,
+Jaakko Parantainen,,,First Worldcon,8/4/2016 12:39:52,jaakkoparantainenkummelista@gmail.com,Tampesteri,Hervanta,Finland,Jaakko,Parantainen,,,,
+Pongo,,,Youth,8/4/2016 12:41:30,pingo@pongo.tv,Dublin,Dublin,Ireland,P,Ongo,6,,,
+Donald Trump,,,Adult,8/4/2016 12:43:42,donald@trump.com,Twitsville,Illinois,The GOOD OL' USA,Donald,Trump,7,,,
+Lempi Lempinen ,,,First Worldcon,8/4/2016 12:45:00,fakefake@email.com,Lovevillage ,,Amoria,,,,,,
+Dennis Mitchell,,,Child,8/4/2016 12:45:49,youllnevercatchmemrwilson@troublemakerheartbreaker.net,Cape Canaveral,Florida,USA,Dennis,the Menace,,,,
+Gandalf the Grey,,,First Worldcon,8/4/2016 12:46:20,gandalf@greyhavens.elf,Shire,,Middle-Earth,Gandalf,the Grey,8,,,
+Mr. Bigbang oohlala,,,Child,8/4/2016 12:47:09,,,,,,,,,,
+Fan McFanface,,,Adult,8/4/2016 12:47:16,mcfanface@gmail.com,Helsinki,,Finland,,,,,,
+Sauron,Supporter,8/4/2016 12:47:23,,,sauron@mordor.com,Mordor,,,,,9,,,
+Fergus Crowley,,,Adult,8/4/2016 12:47:39,fergus@hades.dot.au,Dis,Hades,HELL,Fergus,Crowley,,,,
+T.H.E. End,,,Adult,8/4/2016 12:48:08,1 Deadend Road,Terminus,Final,Nulla,Ted,End,10,,,
+Hermione Targaryen,,,First Worldcon,8/4/2016 12:49:38,harryswife@dragonstone.wes,Meereen,Hogwarts,Slaver's Bay,Hermione,Targaryen,,,,
+Acidia Raine ,,,Youth,8/4/2016 12:49:40,moreacid@fakemail.concon,Gotham,,,,,11,,,
+toru loru,,,First Worldcon,8/4/2016 12:51:00,totulotu@aaa.ee,soomaa,jaani,eesti,totu,lotu,12,,,
+Irma-Perttuli Lampipuhurinen ,,,Child,8/4/2016 12:51:19,irma@perttuli.net,,,finland,irmaperttuli ,,,,,
+Patrick Jane,,,Adult,8/4/2016 12:52:10,patrick.jane@cbi.gov,Sacramento,California,USA,Patrick,Jane,,,,
+Alan Foster,,,First Worldcon,8/4/2016 12:52:46,alanfff@iki.fi,Sydney,NSW,Australia,Alan,Foster,13,,,
+Nasty Butthole,,,First Worldcon,8/4/2016 12:52:59,nasty@butthole.gov,Poopadelphia,Hineyland,Glutania Maximania,Bootylicious,Poopshoot,14,,,
+"Isaura ""the Cat"" astin Eraday",,,Kid-in-tow,8/4/2016 12:54:57,isaura@fakemail.eu,Valdis,,Valdyas,Isa,(none),,,,
+Kooky Doodlehead,,,Kid-in-tow,8/4/2016 12:55:46,whackadoodle@moonpie.com,Goola,Ming,Republic of Dunkybones,Kooky,Doodlehead,,,,
+Bucky Barnes,,,Adult,8/4/2016 12:56:18,buckybarnes@captainamerica.com,New York,,USA,Bucky,Barnes,,,,
+Daenerys Stormborn,,,Adult,8/4/2016 12:56:30,daenerys@queenodtheandals.com,King's landing,Westeros,Westeros,Mother of,Dragons,15,,,
+Meriadoc Brandybuck II,Supporter,8/4/2016 12:56:51,,,merry@shire.org,Hobbiton,The Shire,Eriador,Merry,Brandybuck,16,,,
+Tara Abernathy,,,First Worldcon,8/4/2016 12:57:27,tara@koseverburning.com,Alt Coulomb,Northern Gleb,,,,,,,
+Alysei Athal astin Velain,,,Adult,8/4/2016 12:57:58,king@palace.vl,Valdis,,Valdyas,Athal,Velain,,,,
+Mariel Hill,,,First Worldcon,8/4/2016 12:58:41,email@marielhill.com,Galway,Galway,Ireland,Mariel,Hill,17,,,
+Sam Wilson,Supporter,8/4/2016 12:58:52,,,Falcon@Avengers.com,Washington DC,Washington DC,USA,Falcon,,,,,
+Pullervo Saimaalta,,,Adult,8/4/2016 12:58:53,pullervo@saimaa,Pitkulajärvi,Saimaa,,,,18,,,
+Drizzt Do'Urden,,,First Worldcon,8/4/2016 12:59:44,zakismyfather@menzoberranzan.com,Menzoberranzan,,,,,19,,,
+Legolas Greenleaf,,,Adult,8/4/2016 13:00:42, ,,,Greenwood the Great,,,,,,
+💩💩💩💩💩,Supporter,8/4/2016 13:01:10,,,com+@com@com.com,💩,💩,💩,,,,,,
+Kamala Khan,,,Youth,8/4/2016 13:01:14,,Albany,NY,USA,Ms,Marvel,20,,,
+Esko Mörkö,,,First Worldcon,8/4/2016 13:01:22,esko.morko@morko.tv,Ankkalinna,Hoth,Gondor,Esko,Mörkö,,,,
+Möhmötti Puupparanta,,,Adult,8/4/2016 13:01:28,möhmötti.puupparanta@gmail.com,Tampere,Pirkanmaa,Finland,Möhmötti,Puupparanta,,,,
+Paddington Bear,,,Adult,8/4/2016 13:01:54,padington@teddy.com,Lima,,Peru,Paddy,Bear,21,,,
+Trogdor,,,First Worldcon,8/4/2016 13:01:56,Burninator@gmail.com,Cave,The country side,Internet,Trogdor,la Burninator,,,,
+Steve Great,,,First Worldcon,8/4/2016 13:02:19,greatgreatsteve@fakemail.com,Dublin,,Ireland,Steve,Great,,,,
+M.R. Universe,,,Adult,8/4/2016 13:03:16,iamme@mruniverse.ego,Presses,Pushes,Abs,Me,Universe,,,,
+Katniss Rogers,,,First Worldcon,8/4/2016 13:04:31,mockingjay@avengers.org,n/a,District 12,Panem,Mockingjay,Rogers,22,,,
+Siipiratas Ankka,Supporter,8/4/2016 13:04:46,,,siipiratas@gmail.com,Siippari,Piippari,Veikkonen,Siipiratas,Ankka,,,,
+Mogens Ångström,,,First Worldcon,8/4/2016 13:04:54,mogens@angstrom.fi,Kauniainen,,Finland,Mogens,Ångström,,,,
+Scarlet Witch,,,Adult,8/4/2016 13:04:56,avengers.scarlet.witch@earths.mightiest.net,New York,New York,USA,Wanda,Maximoff,23,,,
+Carol Ní Chonghaile,Supporter,8/4/2016 13:05:06,,,myfakename@yahoo.com,Dublin,Dublin,Rep. of Ireland,CarolC,,,,,
+Laalaa Land,,,Youth,8/4/2016 13:05:31,laalaalandiassaollaan@suomi24.fi,Laiska,Luiska,Land,Laalaa,Land,,,,
+Opun Undo,,,First Worldcon,8/4/2016 13:07:28,rubber@eraser.net,Dodge Town,Iowa,USA,Nualla,Blank,,,,
+Pantsy McPants,,,First Worldcon,8/4/2016 13:07:54,antsypantsy+fake@hotmail.com,Stockholm,,SWEDEN,Pantsy,McPants,,,,
+Maija Mehilainen,,,First Worldcon,8/4/2016 13:08:21,maija@mehilainen.com,Bee Hive City,Bee province,Bee country,Maija,Mehilainen,24,,,
+Mary Poppins,,,First Worldcon,8/4/2016 13:08:24,aaargh.nnghh@eww.com,Helsinki,,Finland,Just,Me,,,,
+WYMAN MANDERLY,Supporter,8/4/2016 13:10:35,,,wayman@whiteharbor.wes,White Harbor,The North,Westeros,WAYMAN ,THE PIEMAN,,,,
+Maria Siirala,Supporter,8/4/2016 13:11:20,,,nowhere@nope.not,Atlantis,Gallifrey,The moon,,,,,,
+Donna Noble,,,Adult,8/4/2016 13:12:15,besttempever@chiswick.co.uk,Chiswick,London,UK,Donna,Noble,,,,
+Melissa Entwhistle,,,First Worldcon,8/4/2016 13:13:24,huzzah@huzzahagain.com,Serendipity,Mastodon,Floramonde,Micro,Fashion,25,,,
+Quicksilver Girl,,,Adult,8/4/2016 13:13:40,qsg@email.com,Starry Night,,,,,,,,
+Amelia Pond,,,Kid-in-tow,8/4/2016 13:14:07,amyandrory@theponds.com,Leadworth,England,UK,Amy,Pond Williams,,,,
+Spendle Backreach,,,Adult,8/4/2016 13:14:23,spendle@aol.noseriously.co.uk,Chang Rai,,Thailand,Spendle,Backreach,26,,,
+Yippieh Ayeih,,,Adult,8/4/2016 13:14:28,Yippiehayeih@gmail.com,Buxtehude,,Germany,Yippieh,Ayeih,,,,
+SELECT count(*) from *.*;,,,Child,8/4/2016 13:14:35,not@real.com,Mallicious,United States,Awkward,Obviously silly test. :) ,Nope,,,,
+Rose Tyler,,,Youth,8/4/2016 13:15:12,rose@otherdimension.org,London,London,UK,Rose,Tyler,,,,
+Jack T. Ladd,,,First Worldcon,8/4/2016 13:16:15,Jackyboy@pan.net,,,,,,27,,,
+Yappa Dappadoo,,,First Worldcon,8/4/2016 13:16:39,Yappadappadoo@hotmail.com,London,,Great Britain,Yappa,Dappadoo,28,,,
+I saw a cake from a distance,Supporter,8/4/2016 13:16:50,,,distance@cake.i.saw,Cakedistant,Isaw,Atadistance,Isawacake,Atadistance,,,,
+Rory Williams,,,Kid-in-tow,8/4/2016 13:17:06,amyandrory@theponds.com,Leadworth,England,UK,Rory,Williams,,,,
+It was a chcocolate cake I think,,,First Worldcon,8/4/2016 13:17:59,itwas@chocolate.cake,Ithink,Distance,Cake,Itwaschcoclate,Ithink,,,,
+Holy Moly,Supporter,8/4/2016 13:18:07,,,Holymoly@yahoo.com,Rome,,Italy,Holy,Moly,29,,,
+Martha Jones,,,First Worldcon,8/4/2016 13:18:38,ilovethedoctor@marthajones.co.uk,London,London,UK,Martha,Jones,,,,
+So I ran quickly towards it,,,Youth,8/4/2016 13:19:05,SoI@ran.quickly.mo,Towards,It,Ranqucik,Soiranquickly,Towardsit,,,,
+But it was just my imagination playing tricks,,,Youth,8/4/2016 13:20:09,itwas@just.my,Imagination,Playing,Tricks,Itwasjustmy,Imagination-Playingtricks,,,,
+Blaargh,,,First Worldcon,8/4/2016 13:21:03,Duh@somewhere.com,HereOrThere,Nope,That One,Tiff,Ehrm,30,,,
+Oswin Oswald,Supporter,8/4/2016 13:21:29,,,suffle@dalek.com,Alaska,Dalek Asylum,Skaro,Oswin,Oswald,,,,
+The New Robert Heinlein,,,Adult,8/4/2016 13:22:09,robert@heinlein.moon,Robert,Heinlein,Moon,New Robert,heinlein,,,,
+Jophan van Boi,,,Adult,8/4/2016 13:22:52,babbhdlorn_78@gmail.com,Minas Tirith,Gondor,Middle-earth,Jophan,the Great,31,,,
+Domenic Jordan,,,First Worldcon,8/4/2016 13:23:03,domenic@jordan.com ,Alestra,Alestra,Alestra,Domenic,Jordan,32,,,
+Hugo McHugoface,,,Adult,8/4/2016 13:23:18,hugo@mchugofa.ce,Hug,Omch,Ugoface,Hugo,McHugoface,,,,
+Why Did the Chicken Cross The Road,Supporter,8/4/2016 13:24:28,,,whydid@thechicken.cro,The Road,Whydid,Australia,Whydidthechicken,Crosstheroad,,,,
+Kate Aldridge ,,,First Worldcon,8/4/2016 13:26:58,elianara@mansion.com,New York City ,New York ,United States ,Kate ,Aldridge ,33,,,
+Clara Oswald,,,Adult,8/4/2016 13:27:29,clara@stolentardis.uni,Blackpool,Lancashire,UK,Clara,Oswald,,,,
+Jack Harkness,,,Adult,8/4/2016 13:29:08,captain@handsome.com,Awesome,Boeshane Peninsula,USA,Captain Jack,Harkness,,,,
+Brune Keare,,,Adult,8/4/2016 13:30:08,krzyczacy@shanvaola.com,Shan Vaola,Zatoka snów,Shan Vaola ,Krzyczący w ciemności ,,,,,
+ Bruce Wayne,,,First Worldcon,8/4/2016 13:33:05,bruce@batman.bat,Gotham City,,United States,Bat,Man,,,,
+Chris Yannic,Supporter,8/4/2016 13:35:22,,,chyann@ucdavis.edu,Davis,California,United States,,,,,,
+Adam Mitchell,,,Youth,8/4/2016 13:35:47,hacker@vanstatten.com,Can't remember,England,UK,Adam,Mitchell,,,,
+Mickey Smith,Supporter,8/4/2016 13:36:46,,,mickeytheidiot@rickey.com,London,England,UK,Mickey,Smith,,,,
+Smurfette,,,Kid-in-tow,8/4/2016 13:37:15,smurfette@smurftown.sm,Smurftown,Blue Woods,Great Waterland,Smurfette,Smurf,34,,,
+Astrid Peth,Supporter,8/4/2016 13:38:05,,,astrid@titanic.uni,Sto,Sto,Sto,Astrid,Peth,,,,
+M. Galbois,,,First Worldcon,8/4/2016 13:38:10,galbois@galbois.com,Luxembourg,Luxembourg,Luxembourg,Stephane,Galb,35,,,
+Felis Undomesticus,,,Adult,8/4/2016 13:38:25,cattish@gmail.com,Catopolis,Catnagar,Kuching,Kuching ,Hitam,36,,,
+Sarah Jane Smith,,,Adult,8/4/2016 13:39:23,sarahjane@unit.co.uk,Foxgrove,England,UK,Sarah Jane,Smith,,,,
+Mistress of the Wooden Spoon,,,First Worldcon,8/4/2016 13:39:54,spoonsrus@yippee.com,Spoonville,Oucharama,Kink Nation,Mistress,of the Wooden Spoon,,,,
+Elizabetha von Finn,,,First Worldcon,8/4/2016 13:39:58,elizabetha.vonfinn@fakeemail.fake,Jäniksenselkä,Keski-Suomi,Finland,Elza,von Finn,,,,
+Wilfred Mott,Supporter,8/4/2016 13:40:27,,,wilf@noble.com,Chiswick,London,UK,Wilfred,Mott,,,,
+Mother of Dragons,,,First Worldcon,8/4/2016 13:40:50,Motherofdragons@fantasy.com,Meereen,Essos,Westeros,Daenerys,Targaryen,,,,
+Leonardo da Vinci,,,Kid-in-tow,8/4/2016 13:41:13,Leonardo.is.the.greatest@genius.com,Da Vinci,,Italia!,Leo,DaV,37,,,
+Evelyn Craven,,,Youth,8/4/2016 13:42:49,EvelynCraven@evelyncraven.com,London,London,UK,Evelyn,Craven,38,,,
+Noodledipoodle,,,Kid-in-tow,8/4/2016 13:43:24,Noodles.poodles@com,Spaghetti Town,Lasagnia,Pasta Heaven,Maccaroni,Cheese,,,,
+Kasa Obake,Supporter,8/4/2016 13:43:54,,,Fake@Email.com,Not,My,Real Address,Kasa,Obake,,,,
+Vilunki-Petteri,,,First Worldcon,8/4/2016 13:43:59,vilunki-petteri@nope.com,Turku,,Finland,Vilunki-Petteri,Kusettaja,39,,,
+Melody Pond,,,Child,8/4/2016 13:45:51,melody@pond.com,Demons Run,Demons Run,Demons Run,Melody,Pond,,,,
+Vox Day,,,Child,8/4/2016 13:46:01,vox@day.com,Rome,,Italy,Teddy,Beale,40,,,
+River Song,,,Adult,8/4/2016 13:46:39,river@badass.com,Leadworth,England,Great Britain,Doctor River,Song,,,,
+Strawberry Sundae,,,Youth,8/4/2016 13:46:44,Strawberry-icecream@heaven.com,Icecreamparlor,Vanilla,Gelato,Lady,Berry,,,,
+Happy Bladder,,,First Worldcon,8/4/2016 13:47:15,Happydotcom@com.com,Bubbling pub,,Pen Island,Happy,Bag,,,,
+Craig Owens,,,Kid-in-tow,8/4/2016 13:47:44,craig@stormageddon.co.uk,Colchester,England,UK,Craig,Owens,,,,
+Dr. Victor Von Doom,Supporter,8/4/2016 13:48:00,,,Dr.Doom@doom.com,Doomstad,,Latveria,Victor,Von Doom,,,,
+Ada Celeritas,,,Adult,8/4/2016 13:49:21,Adaceleritas@arsmagica.com,Cad Gadu,Stonehenge Tribunal,Wales,Ada,Celeritas,41,,,
+Alli Paasikivi,,,Youth,8/4/2016 13:53:56,a.paasik@meili.zxc.fin,Porvoo,,Åland,Alli,,,,,
+미라,,,Youth,8/4/2016 13:54:38,mira@hanmail.net,서울,서울특별시,대한민국,미라,,,,,
+Fakey McFakeface,,,First Worldcon,8/4/2016 13:55:18,mail@fakemail.com,Here,That place,There,,,,,,
+Juho Kusti,,,First Worldcon,8/4/2016 13:56:24,,Turku,,Finlandia,,,42,,,
+Throat Warbler Mangrove,,,First Worldcon,8/4/2016 13:58:12,NowWhatsAllThisThen@Hello.wot,Sweer Island,Gulf of Carpenteria,Australia,Raymond,Luxury-Yatch,43,,,
+Мрако Беснишки,,,First Worldcon,8/4/2016 14:01:05,mb@nosuch.net,Knot ere,,EU,Мрако,,44,,,
+Blue Jeep,,,Adult,8/4/2016 14:07:34,bluejeep61@mail.com,,,Oman,Blue,Jeep,,,,
+Suska,,,First Worldcon,8/4/2016 14:07:56,,Lappeenranta,,Finland,,,45,,,
+Irving Washington,,,Adult,8/4/2016 14:08:11,washington.irving@snorglebürg.ie,Snorglebürg,Bad-Snorglebürg,Irelland,Vashington,Irwing,46,,,
+Lord Meow Meow,,,First Worldcon,8/4/2016 14:10:12,Fuzzyface@gmail.com,Purrington,Blarghles,Kittentopia,Bubbles,Meow Meow,,,,
+Lord Tiberius Squee,,,First Worldcon,8/4/2016 14:11:12,tibbysquee@westeros.got,King's Landing,King's Landing,Westeros,Tiberius,Squee,47,,,
+Jeanne-Elise de la Tourelle Fitou,,,Adult,8/4/2016 14:12:18,labellemarquise@mousquetaires.fr,Paris,Bretagne,Bretagne,Sylvan,None,,,,
+Olivia Oil,,,Adult,8/4/2016 14:14:26,asdfasf@fge.de,Hamburg,Hamburg,Deutschland,Olli,Oil,48,,,
+Rene d'Herblay,,,First Worldcon,8/4/2016 14:14:27,aramis@mousquetairs.fr,Paris,Les Vosges,La Belle France!,Aramis,,49,,,
+Giant Panda,,,First Worldcon,8/4/2016 14:16:40,,Aachen,,Germany,Giant,Panda,,,,
+Sally Warner,,,First Worldcon,8/4/2016 14:18:48,Sally.Warner@mail.com,Manchester,England,UK,Sally,Warner,,,,
+Boxer Heelgood,,,Kid-in-tow,8/4/2016 14:19:17,makeawash@tawdry.tv,Humptulips,Washington,USA,Nancy,Drew,50,,,
+Regina Phalange,,,First Worldcon,8/4/2016 14:20:17,you@yourmum,New York,Noo Yawk,South Korea,Princess Consuela,Banana-Hammock,,,,
+Alec Ramsay,,,First Worldcon,8/4/2016 14:20:25,IlovetheBlack@stallion.com,New York,NY,USA,Alec,,51,,,
+Zaphod Beeblebrox CXXIII,,,Kid-in-tow,8/4/2016 14:20:27,heart.of.gold@stolen.net,Galaxyville,The Universe,Space-Time Continuum,Ford,Prefect,,,,
+Årån-Öän Ənndœ,,,First Worldcon,8/4/2016 14:21:07,what's it to you?,Sjır,N/A,Vinland,Årån-Öän,Ənndœ,52,,,
+Creator of acorns,,,Kid-in-tow,8/4/2016 14:25:19,redoak@treefarm.org,Forrest City,Taiga,Mother Tree,Adolf,Acorn,53,,,
+BunnyCat,,,Adult,8/4/2016 14:25:30,BunnyFromHell@gmail.com,Ytre Enebakk,Akershus,Norway,Bunny,Cat,,,,
+Freda bloggs,,,Youth,8/4/2016 14:26:07,freda.bloggs@wherever.com,Brighton,Surrey,Belgium,Freda,Mindyourown,54,,,
+Ørjan Gålbærg,,,Kid-in-tow,8/4/2016 14:26:28,Maybetoo@yes.no,Oslo,,Norway,Ørjan,Gålbærg,,,,
+Inigo Montoya,,,Adult,8/4/2016 14:27:48,prepare@die.die.die,Capital City,Land of far away,dangerous,Inigo,Montoya,55,,,
+Dirk Hardfist,,,First Worldcon,8/4/2016 14:28:08,david.cameron@oink.com,Reseune ,New Gehenna,Cyteen,Arianne,Emory,56,,,
+SadPuppy2479,,,Child,8/4/2016 14:28:41,sadpuppy2479@hotmail.com,Fedoraville,The Vale of Man-Tears,USA,Saddest,Puppy,57,,,
+Claude Deglar,,,First Worldcon,8/4/2016 14:30:09,Claude@ozarklovecamp.com,Muncie,IN,United States,Claude,Deglar,58,,,
+DeerVölt,,,Kid-in-tow,8/4/2016 14:30:10,nakke@nakutta.ja,Helsinski,Juusimaa,Funland,Narsku,Lorsku,,,,
+Bressica Tantalus,,,Adult,8/4/2016 14:32:20,btant@fabulous.tld,London,Kansas,Australia,Bress,,,,,
+Loana Miriam,,,Kid-in-tow,8/4/2016 14:33:08,Qser@der.vn.com,Hcmc,N/A,Vietnam,Hoa,Nguyen,59,,,
+Turhikki Möhnä-Kikkare,,,First Worldcon,8/4/2016 14:35:34,turhikki@geemail.con,Tiuskanpohja,Nälviä,Vuolangan vapaavaltio,Turhikki,Möhnä-Kikkare,60,,,
+Roy Batty,,,Kid-in-tow,8/4/2016 14:37:03,doandroidsdreamofelectricsheep@tyrrell.biz,San Francisco,CA,Orion,Roy,Batty,61,,,
+Herbert J Gruntfuttock,,,Adult,8/4/2016 14:37:14,hj@gruntfuttock.co.uk,London,,UK,John,Doe,62,,,
+Glorious Falsity,,,Adult,8/4/2016 14:43:10,fake@fakeness.fake,Falcity,Fakeplace,Fakeness,Glory,TRUE,,,,
+Helanius Bigglesworth,,,First Worldcon,8/4/2016 14:45:45,Bobama@whitehouse.gov,Intercourse,PA,Belize,Quinoa,Fromagiere,,,,
+Gerbil Hubernough,Supporter,8/4/2016 14:50:17,,,gargle33.2guppmail.com,Fakevile,Ohio,USA,The Mighty Gerbil,,,,,
+Tufflm Girdflump,,,Adult,8/4/2016 14:50:28,tgirdflump@gmail.com,Mumbai,Kenyatta,India,Tufflm,Girdflump,,,,
+Lance Armstrong,,,First Worldcon,8/4/2016 14:50:41,lance@livestrong.org,Houston,Texas,USA,Lance,Armstrong,,,,
+Email with Plus in it,,,Youth,8/4/2016 14:54:40,email+foo@example.com,,,,,,,,,
+Mahlah Zelophehad Manasseh,,,Kid-in-tow,8/4/2016 15:05:22,emzy_manasseh@gotmail.com,Gilead,MA,USA,Emzy,Manasseh,63,,,
+Arthur Dent,,,Adult,8/4/2016 15:06:19,Arthur.dent@bbc.co.uk,Cottington,Somerset,UK,Arthur,Dent,,,,
+Kellosepän jalkavaimon käsväsky,,,Kid-in-tow,8/4/2016 15:10:47,Väskyläinen@citissä.nero,Kaapin takana naulakko,Ylin oksa,Kellosepän kellari,Neulottu,Tyylikäs-käsväsky,64,,,
+Archer de Grundy Penny-Hassett,,,First Worldcon,8/4/2016 15:11:02,archer@penny-hassett.co.uk,Blairgowrie,Perthshire,United Kingdom,Archer,Penny-Hassett,,,,
+Mentega Kuning,,,First Worldcon,8/4/2016 15:12:34,mentega.kuning@gmail.com,Lembu Town,Biri Valley,People's Republic of Padang,Mentega,Kuning,,,,
+Jorma Ei-Aivan-Uotila,,,Adult,8/4/2016 15:13:35,jortsuboy69@hotmale.com,Melkein Helsinki,,Sumoi,Pertti,Peräpeikkola,65,,,
+Firstname La Stname,,,First Worldcon,8/4/2016 15:16:49,FirstnameLaStname@nowh.ere,This Town,Rhode Island,USA,Firstname,,,,,
+"O'Fish, Al",,,Kid-in-tow,8/4/2016 15:17:20,dsf<sdafkd<fhkas+dfhldfjsha@example.com,Paris,France,France,Al,O'Fish,,,,
+ 中国人,,,Adult,8/4/2016 15:21:19,zhong.guo.ren@outlook.com,Shanghai ,Pudong,People's Republicbod China,大,饭熟,,,,
+Oma Nimi,,,Kid-in-tow,8/4/2016 15:22:34,eiole@gmail.com,Springfield,Satakunta,Islanti,Pöötöimiiköääkköseť,Al Khaleb bin Rasmus,,,,
+Isaac Asimov,,,Child,8/4/2016 15:22:59,ike@asimov.com,New York,New York,USA,Isaac,Asimov,,,,
+Maija Mehiläinen,,,First Worldcon,8/4/2016 15:23:22,maija.mehilainen@thehive.com,Tampere,Pirkanmaa,Finland,Maija,Mehiläinen,,,,
+Seleya Smith,,,Child,8/4/2016 15:23:49,vulkan@mail.it,Florence,Tuscany,Italy,Seleya,Smith,66,,,
+K Tomato,,,Youth,8/4/2016 15:27:24,moviesRus@planet9.space,Smallville,Gotham,Mars,Killer,Tomato,,,,
+Radamsa,,,Kid-in-tow,8/4/2016 15:32:14,,"Sink, Under the",,,Snadaff,Uhmuh,67,,,
+Bilbo Baggins,,,First Worldcon,8/4/2016 15:34:21,bilbo@hobbittown.com,The Shire,The Shire,Middle Earth,Bilbo,,,,,
+Ildikó James,,,Adult,8/4/2016 15:35:15,ijames@ei.oo,Budapest,,Hungary,Ildikó,James,68,,,
+Nikke Knakkerton,,,Adult,8/4/2016 15:44:19,nikke@mct.blergh,Kyritz,Landkreis Ostprignitz-Ruppin,Brandenburg,Nikke,Knakkerton,69,,,
+Mary Poppins,,,Adult,8/4/2016 15:44:33,mary.poppins@banksresidence.co.uk,London,London,UK,Mary,Poppins,,,,
+Iina Kuusipuu,,,First Worldcon,8/4/2016 15:52:08,Kuusipuu@sysimetsa.fi,Korpi,,Maameri,Sanni,Aurinkoinen,,,,
+Heikki Bae,,,First Worldcon,8/4/2016 15:57:15,bae@baebae.com,Baelandia,Baemaa,Baeland,Heikki,Bae,,,,
+Klingon Number 1,,,Adult,8/4/2016 15:58:30,NumberOne@mac.com,San Jose,CA,USA,One,,,,,
+Smedley T. Smedford,,,Adult,8/4/2016 16:00:44,smedsmed@smedley.org,Galaxy City,Rhode Island,USA,Smedley,Smedford,70,,,
+Mikko Mallikas,,,Adult,8/4/2016 16:03:59,mikko@mallikas.fi,,,Sweden,Mikko,Mallikas,,,,
+Jim Stoneheart,,,Adult,8/4/2016 16:08:46,WillRiseAgain@sunspear.se,Caemlyn,Eros,The Belt,Amos,Avasarala,,,,
+Tootles McBride,,,Adult,8/4/2016 16:10:14,Tmb@example.org,Birmingham,Staffordshire,United Kingdom,Toot,McBride,71,,,
+Kimiko Weasley,,,First Worldcon,8/4/2016 16:12:29,Immadeofcats@gmail.com,Portland,OR,USA,Kimiko,Weasley,,,,
+Jo Helder,,,Adult,8/4/2016 16:13:36,jo.helder+Wcon@gmail.com,Cambridge,Cambridgezhire,United Kingdom,Joanne,Helderine,,,,
+Qwertyuiopasdfghjklzxcvbnm1 Qwertyuiopasdfghjklzxcvbnm2 Qwertyuiopasdfghjklzxcvbnm3 Qwertyuiopasdfghjklzxcvbnm4 Qwertyuiopasdfghjklzxcvbnm5 Qwertyuiopasdfghjklzxcvbnm6 Qwertyuiopasdfghjklzxcvbnm7 Qwertyuiopasdfghjklzxcvbnm8 Qwertyuiopasdfghjklzxcvbnm9 Qwertyuiopasdfghjklzxcvbnm10,,,First Worldcon,8/4/2016 16:17:29,!#$%&'*+-/=?^_`{|}~@invalid.net,😎😡,∆∏,✈︎⚓︎,,,72,,,
+Minnie Musa,Supporter,8/4/2016 16:17:41,,,umustbjoking@hercmail.org,Victoria,BC,Canada,Minnie,Musa,73,,,
+"Help, I'm stuck in an elevator!",,,Adult,8/4/2016 16:26:09,helphelphelp,Essen,,Germany,No,Name,,,,
+Bill Bobbington,,,Adult,8/4/2016 16:28:35,Dfghhj@ffhhk.com,Newtownabbey,Antrim,United Kingdom,Bill,Bobbington,,,,
+大 吳,,,Adult,8/4/2016 16:29:46,大吳@wu.id.au.example.invalid,beijing,,中国,中小,吳,,,,
+Fred Perry ,,,Adult,8/4/2016 16:34:37,Fred@perry.com,North Hollywood ,Ca,Usa,Dave,Dave,,,,
+Hugh Kyril Sacristan,,,Adult,8/4/2016 16:36:56,hughsac@avevalecollege.org.uk,Avevale,Kingsland,Britain,Paul,Harding,,,,
+Yrjö Äijö,,,Adult,8/4/2016 16:37:28,yrjoaijo@jippii.com,Nikolainkaupunki,Länsi-Suomi,Finland,Yrjö,Äijö,74,,,
+Barbara Wellesley,,,Youth,8/4/2016 16:42:07,bewell@aCloud.com,Dublin,,Ireland,Barbara,Wellesley,,,,
+Crochet Queen,,,Kid-in-tow,8/4/2016 16:44:00,notaknitter@yarnlovers.com,Sheepsville,Wool Land,Yarnheads,Crochet,Queen,,,,
+Ääkköñen Ääkötsalo,,,Adult,8/4/2016 16:51:07,erich.mielke@stasi.dd,Kerakekoski,,Finland,Ääkkönen,Ääkötsalo,75,,,
+Justin Treudeau,,,First Worldcon,8/4/2016 16:56:14,dontask@gmail.com,Canada,Canada,CANADA,Justin,McSexy Treudeau,76,,,
+叶文洁,,,First Worldcon,8/4/2016 16:57:37,yewenjie@ttbp.com,长春,吉林,中国,统帅,文洁,77,,,
+C Lê,,,First Worldcon,8/4/2016 16:58:07,cle@yahoo.co.uk,NYC,New York,USA,,Lê,,,,
+小灵通,,,Adult,8/4/2016 17:00:50,future@faa.com,上海,上海,中国,小,灵通,78,,,
+The Doctor,,,Adult,8/4/2016 17:00:58,TenthDoctor@tardis.com,Sexy,Gallifrey,The Universe,The,Doctor,79,,,
+Zaphod II,,,First Worldcon,8/4/2016 17:01:08,Blaster Way,Blaster City,YN,Caprica,Zaphod,II,,,,
+Bellosi,Supporter,8/4/2016 17:02:11,,,Supporterbel@nix.com,Blueden,SK,Canada,Blue,Silly,80,,,
+Ezekiah Horobowicz,,,Adult,8/4/2016 17:05:33,sweetie@edgeoftheunivers.com,Picklegritz,Maine,USA,E-Z,Horobowicz,81,,,
+Medusa Sanctuary,,,Adult,8/4/2016 17:06:34,medusa4tehgillz@gmail.com,Lewisporte,Newfoundland ,Canada,Medusa,Sanctuary ,82,,,
+JRR Lewis,,,Adult,8/4/2016 17:06:40,inklings@pub.co.ukish,Cair Paravel,Mordor,Narnia,JRR,Lewis,83,,,
+Ürsa,,,First Worldcon,8/4/2016 17:07:47,wårldkøn@fakeaddress.gn,მეტროპოლია,நாங்கள்,Ïs,Ø;rperth,ცხენი,84,,,
+Marion Morrison,,,Adult,8/4/2016 17:08:25,Theduke@fortapache.mil,San Antonio,Tx,USA,The,Duke,,,,
+Ifihada Hammer,,,Child,8/4/2016 17:11:34,,,,,,,85,,,
+Harriet Pottery,,,Adult,8/4/2016 17:15:11,,,,,,,,,,
+Freddy Mercury,,,Kid-in-tow,8/4/2016 17:18:24,Queen@britain.uk,Liverpool,,Great Britain,Freddy,Mercury,86,,,
+Sir Arthur Strong (Mrs.),,,Child,8/4/2016 17:20:28,MeatLover@ding.dong,Pännäinen,Pohjanmaa,Finland,Throatwobler,Mangrove,,,,
+Janina Kozieł,,,First Worldcon,8/4/2016 17:21:31,jkoziel@o2.pl,Gdańsk,Pomorskie,Poland,Bzium,Ąęóśćż,,,,
+Rangoon Obama,,,First Worldcon,8/4/2016 17:24:27,Big.pits@bhs.com,Prague,Oklahomer,India,Ranulph,The Uninspired,87,,,
+Max Syöttöpaine,,,Adult,8/4/2016 17:28:07,max@syottopaine.fi,Tampere ,,Finland,Max,Syöttöpaine,,,,
+Fresh Prince,,,Adult,8/4/2016 17:30:15,will@jazzyjeff.com,Bel Air,California,USA,Will,Smith,,,,
+James Tiberius Kirk,,,Child,8/4/2016 17:31:58,jtkirk@starfleet.org,,Iowa,USA,James,Kirk,,,,
+Lomion,,,First Worldcon,8/4/2016 17:32:04,lomion@gondolin.com,Gondolin,Tumladen,Beleriand,Maeglin,Lomion,,,,
+Floney McFlooloo,,,Kid-in-tow,8/4/2016 17:32:58,spam@spam.spam.spam.spam.spam,Guantanamera,Guantanamera,GuantanaMERa,Floney,McFlooloo,88,,,
+BigNostrils Tony,,,Kid-in-tow,8/4/2016 17:34:53,Sexyfishlips@aol.com,Bumshart,Nebrahoma,Norwegia,BigNostrils,Tony,,,,
+Arthur C. Clarke,,,Child,8/4/2016 17:35:26,childhoods@end.com,Rama,,Rama,Arthur C.,Clarke,89,,,
+Alanna of Trebond and Olau,,,Adult,8/4/2016 17:35:58,thelioness@tortall.com,Port Caynn,Olau,Tortall,Alanna,Olau,,,,
+Bob bobman ,,,Adult,8/4/2016 17:36:25,Sdh@f.com,New York ,Ny,United States ,Bob,Bobman,90,,,
+Poke Stop,,,First Worldcon,8/4/2016 17:39:24,Pokestop@stop.com,Beuford,DC ,Usa,Poke,Stop ,91,,,
+Americas Next Top Fondler,,,Adult,8/4/2016 17:40:03,Buttfulloftrumpets@compuserv.net,Crincklesack,Clitoropolis,Geidi Prime,Barry,McCockiner,,,,
+ יצחק בן אברהם,,,Child,8/4/2016 17:40:26, יצחק@אינטרנט.הו,כְּנַעַן,כְּנַעַן,ישראל, יצחק, בן אברהם,,,,
+Anthony Caracterus Flewellen Gripewater-Thynne IV,,,Adult,8/4/2016 17:41:59, 囍@example.com ,Luna,Luna,N/A, 囍 ,,92,,,
+Tasha Lennhoff ,,,Adult,8/4/2016 17:51:04,tasha_turner@fake.com,Highland Park,NJ,USA,Tasha,Turner Lennhoff ,,,,
+Asthore MacRowyn,,,First Worldcon,8/4/2016 17:51:20,asthore@brittanis.larp,Cornerstone,Albion,Brittanis,Asthore,MacRowyn,,,,
+Keladry,,,Adult,8/4/2016 17:53:55,ladyknight@tortall.org,Mindelan,Northern Tortall,Tortall,Keladry,Mindelan,,,,
+JRR Tolkien ,,,First Worldcon,8/4/2016 17:55:21,Jrrt@middleearth.com,Minas Tirith,Gondor ,Gondor ,Professor,T,93,,,
+Nikolaj Ivanovich Lobachevsky,,,First Worldcon,8/4/2016 17:55:49,Петербург@xmail.com,Петербург,ny,Петербург,Петербург,Петербург,,,,
+Bènnifër Fôcjestār,,,Adult,8/4/2016 17:57:26,The Willow Arms,Ætherton,Bârstow,US,Puddin,Täyn,,,,
+Fred Mouse,,,First Worldcon,8/4/2016 18:00:34,fred.mouse@aol.online,Yellow Knife,,Canada,Fred,,,,,
+Rhys Gwyn 'ten Boom,,,First Worldcon,8/4/2016 18:00:39,rhysgwyn@llys.cy,Llangollen,Cantre' Gwaelod,Cymru,Rhys Gwyn,ten Boom,,,,
+Duncan McLeod,,,First Worldcon,8/4/2016 18:01:17,dmc@skyfall.sco,Timbuktu,,The future,Hello,World,94,,,
+Marialegre Alfarero,,,Adult,8/4/2016 18:09:22,,Mexico City,Guanajuato,Mexico,Marialegre,Alfarero,95,,,
+Vanta Black,,,First Worldcon,8/4/2016 18:10:46,vantaawkbot12@hotmail.com,Derry,Maine,USA,Vanta,Black,96,,,
+Lady Peter Wimsey,,,Adult,8/4/2016 18:13:38,detectivemoll@writ.uk,London,,England,Harriet,Wimsey,97,,,
+Bjørn Årnót,Supporter,8/4/2016 18:14:04,,,bjorn.arnot@not.fi,Vega,-,Finland,Bjørn,Årnót,,,,
+"Foo Bar, Jr.",Supporter,8/4/2016 18:16:30,,,foo@bar.comz,Foo City,Bar State,Foobar Republic,Allan,Foobar,98,,,
+Daavid Inkeroinen ,,,Kid-in-tow,8/4/2016 18:21:34,Simppu.lsunda@usa.net,Östersundom,Machiavelli,Sedna,Taavi,Inkkula,99,,,
+Okay,,,First Worldcon,8/4/2016 18:24:42,doodaa@deedoo.au,Lunar Orbit,Skullcity,Mars,Sizzle,Pop,100,,,
+Brew Haha,,,First Worldcon,8/4/2016 18:26:26,brewhaha@yahoo.net,Beer City,Illinois,USA,Brew,,,,,
+Lady Di,,,First Worldcon,8/4/2016 18:29:04,Di-NaMight@tower of London. Uk,The Moors,Left of Center,Half Baked Potato Land,Lady Di,,,,,
+Smee Smee,,,First Worldcon,8/4/2016 18:45:50,tigers@arecute.com,London,London,United Kingdom,TIGERS,ARE-CUTE,101,,,
+Jo Bitfsplk,Supporter,8/4/2016 18:46:40,,,jo@jobitfsplk.com,Bitfsplkville,VT,USA,Jo,Bitfsplk,102,,,
+Ralph Malph,,,Adult,8/4/2016 18:46:43,devnull@deltos.com,McKinney,TX,US,Ralph,Malph,,,,
+Melvin Morsmere,,,Adult,8/4/2016 18:50:09,melvin@squidlips.com,Tacoma,WA,USA,Peduncle Q.,Mackinaw,103,,,
+Skarrin Kilgarrin,,,First Worldcon,8/4/2016 19:01:12,Blee@bloo.net,Skarrinville,WA,USA,Skarrin,Kilgarrin,104,,,
+Renauld Franenstien,,,First Worldcon,8/4/2016 19:07:28,REnnie@nappy.yuk.uk,London,London,Uk,Rennie,Frank,105,,,
+Sabrina Vorkosigan,,,Kid-in-tow,8/4/2016 19:09:14,Daddy@nappy.yuk.uk,Newcastle,The grim Northlands,UK,Kitty ,Kat,,,,
+Soup Dragon,,,Adult,8/4/2016 19:10:52,soupdragon@Clangers.planet,Star City,Asteroid belt,UK,Soupy,,,,,
+Ford Prefect,,,Adult,8/4/2016 19:12:03,Ford@hitchhikersguide.vogon,London,UK,,Ford,,,,,
+Pinkie pie,,,Child,8/4/2016 19:13:09,mummy@nappy.yuk.uk,Bristol,Avon,UK,Baby,,,,,
+tweety pie,,,Youth,8/4/2016 19:14:22,bird@bird.bird,Birdsvelle,,UK,Tweety,,,,,
+Mrs Slartibartfast,,,First Worldcon,8/4/2016 19:19:48,slartibartfast@hotletter.com,Brigadoon,Teuchterland,Scotland,Istina,Pronkovic,,,,
+Rękosław Samodzielny,,,First Worldcon,8/4/2016 19:20:43,RasiaSamosia@buziaczek.wp.pl,Chrząszczyżewoszyce,Łękołody,Poland,Rękosław,Samodzielny,106,,,
+Galadriel of House Finarfin,,,Adult,8/4/2016 19:20:47,galadriel@lothlorien.fi,LothLorien,woods,Middle-earth,Galadriel,Galadriel,,,,
+Tina Belcher,,,Youth,8/4/2016 19:20:49,tina@burgertown.net,Seymour's Bay,Rhode Island,United States,Dina,Belcher,107,,,
+Legolas aka the dainty footed elfling,,,First Worldcon,8/4/2016 19:27:17,legs-so-daint@elfdom.elf,Woodland Realm,Mirkwood,Middle Earth,Legolas,Thranduilson,,,,
+Bert and Ernie,,,First Worldcon,8/4/2016 19:33:07,thisisatest@test.com,Oklahoma City,OK,USA,Bert,Ernie,108,,,
+Putinoid,,,First Worldcon,8/4/2016 19:43:11,idiot@kremlin-kgb.com,Северополюсовск,Лагерь,Российская Умудряция,Путиноид Ленинович, Сталин-Добанутый,109,,,
+Євроїжак / Eiroizhak,,,Child,8/4/2016 19:45:49,izhachek@super-ukraine.com,Бердичів,Вінницька область,Україна,Євросла,Українець,,,,
+Badger Comedian,,,Adult,8/4/2016 19:57:11,mail@badgerandboodle.com,Sedgely ,West Midlands ,England ,Badger ,McGinley ,,,,
+Василий Пупкин,,,Adult,8/4/2016 19:57:30,"Зареченская губ., г. Мухосранск, ул. Нахренацкая, 18",Мухосранск,Зареченская губерния,Рутения,Василий,Пупкин,,,,
+Edgar Allan Poop,,,Child,8/4/2016 19:57:50,edgar@example.com,Somewhere over the Rainbow,Nowhere,Disunited Kingdom,Edgar,Allan,110,,,
+Висисуалий Лаханкин,,,First Worldcon,8/4/2016 20:02:15,"Молдаванка, Воронья слободка, 3",Черноморск,Черноморская область,Портофранция,Висисуалий,Лоханкин,111,,,
+Вовочка Ложкин,,,Child,8/4/2016 20:05:25,"Старых Козлов, 15, кв. 6",Урюпинск,Симбирская губ.,Русланд,Вовочка,Ложкин,,,,
+Twix the Mad Dog,,,Kid-in-tow,8/4/2016 20:18:42,Twix@twixietwix.fm,Toronto,Surrey,Belarus,Twix,Doctor,,,,
+Valrhona Moose,,,First Worldcon,8/4/2016 20:21:28,valrhona@chocolatemoose.org,Birmingham,West Midlands,England,Valrhona,Moose,,,,
+לגיטימי חגמצגמדל,,,Adult,8/4/2016 20:22:56,מכמגמג@חגנכמגל,"ידי הגמל,",מכלא׳,צכלכלםא,ממדיכ(,נסיכי<,112,,,
+Lisa-Oscar de la Kärvistys,,,First Worldcon,8/4/2016 20:23:17,foo+bar@mail.example.org,Ougadougou,-,Burkina Faso,<3,de la Kärvistys,,,,
+Wrigley,,,Adult,8/4/2016 20:23:18,wrigley@chocolatemoose.org,Solihull,West Midlands,United Kingdom,Wrigley,Caterpillar,,,,
+<script>alert(1)</script>,,,Child,8/4/2016 20:28:22,foo.bar@example.ninja,<script>alert('2')</script>,"<script>alert(""3"")</script>",<script>alert(4)</script>,<SCRIPT SRC=http://xss.rocks/xss.js></SCRIPT>,"<IMG SRC=""javascript:alert('XSS');"">",113,,,
+Fakey MacFakerston,,,Adult,8/4/2016 20:31:09,fmf@fakey.example.com,Portland,OR,USA,Fake,MacFakerston,114,,,
+x' OR full_name LIKE '%Bob%,,,Youth,8/4/2016 20:34:48,x' AND email IS NULL; --,x' AND 1=(SELECT COUNT(*) FROM tabname); --,anything' OR 'x'='x,Finland,x'; DROP TABLE members; --,Hacker,115,,,
+Kaywinnet Lee Frye,Supporter,8/4/2016 20:48:56,,,kaylee_unicorn@serenity.brown,Classified,Classified,a Core planet,Kaylee,Fry,116,,,
+Falsity Tanner,,,First Worldcon,8/4/2016 20:51:16,Falsity@RDC.com,Wales,MA,USA,Fanny,Tanner,117,,,
+Spiro T Agnew,,,First Worldcon,8/4/2016 20:54:39,spiro@agnew.com,Washington,DC,USA,Spiro,Agnew,118,,,
+Arya Stark,,,Youth,8/4/2016 20:56:51,winter@is.coming,Winterfell,The North,Westeros,A Girl has,No name,119,,,
+Rommi,,,Adult,8/4/2016 21:04:08,Caribean@car,Havanna,,Pirate union,Rommi,Blackbeard,120,,,
+FitzChivalry Farseer,Supporter,8/4/2016 21:06:53,,,fitzchivalry.farseer@sixduchies.gov,Buckkeep,Buck,Six Duchies,Fitz,Farseer,,,,
+Kettricken of the Mountains,,,Adult,8/4/2016 21:08:14,Kettricken.Queen@sixduchies.org,Buckkeep,Buck,Six Duchies,Kettricken,,,,,
+Chivalry Farseer,,,Adult,8/4/2016 21:09:57,Chivalry.Prince@sixduchies.org,Buckkeep,Buck,Six Duchies,Prince Chivalry,Farseer,121,,,
+"Michael ""Goob"" Yagoobian",,,Adult,8/4/2016 21:23:52,goobian@goobmail.net,Chicago,Illinois,United States of America,Bowler Hat,Guy,,,,
+Vitruvius,Supporter,8/4/2016 21:29:53,,,masterbuilder1937@lego.movie,Amersterdam,North Holland,Kingdom of the Netherlands,Morgan,Freeman,122,,,
+Ariana Yli-Yrity's,,,First Worldcon,8/4/2016 21:38:42,Yli-yritys@jokuposti.fi,Kontu,-,Hobittila,Ary,YY,,,,
+Alana Landfall Capulet,,,First Worldcon,8/4/2016 21:39:08,badasslandfallianmama@run.hide,Wingspan,West Side,Landfall Landmass,Alana,Saga,,,,
+Lola Numjaker,,,First Worldcon,8/4/2016 21:57:15,yawanityagotit@somemail.ca,Moscova,,Monrovia,Topheavy,Woman,123,,,
+Regnad Kcin,,,Adult,8/4/2016 22:18:38,danger@fake.com,The City,Solidstate,Freedonia,Regnad,Kcin,124,,,
+Paradoxical Astral Fairy,,,First Worldcon,8/4/2016 22:23:21,fairy@none.com,Utopia,,Atlantis,You're Not,Serious,,,,
+Noodle McNoodface,,,First Worldcon,8/4/2016 22:31:37,Noodynoodnoodnoodlington@nood.com,Cottonwood,Arizona,United States,Nana,McNoodFace,125,,,
+Silly Lilly vonWigglesbottom,,,Youth,8/4/2016 22:32:55,actuallymycat@actuallymycat.com,Cat Tower,VA,Roanoke,Kitteh,Hsu,,,,
+Kathryn Airey,,,Youth,8/4/2016 22:34:33,kja@maths.mf.ac.uk,Okehampton,Devon,United Kingdom§,,,126,,,
+River Song,,,Adult,8/4/2016 22:42:28,river.song@51stcentury.net,Everywhere,Everywhere,All of time and space,,,,,,
+Shadow Moon,,,Adult,8/4/2016 22:45:19,shadow@moon.com,House on the Rock,Wisconsin,America,Shadow,Moon,,,,
+Τηλέμαχος,,,Youth,8/4/2016 22:47:32,,,Ιθάκη,Ελλάδα,Τηλέμαχος,,127,,,
+Breq Mianaai,,,First Worldcon,8/4/2016 22:50:39,captain@mercyofkalr.rd,Athoek Station,Athoek,The Radch,,<i>Justice of Toren</i>,,,,
+I have a public first name but not a public last name. Let's see if it gets recorded in the database properly.,Supporter,8/4/2016 22:58:33,,,awkward@example.com,Bristol,Avon,England,Venturus,,,,,
+Abby Yates,,,Adult,8/4/2016 23:10:13,theyRreal@ghostbusters.ca,"Neutron City, Alberta",Alberta,Kanata,Keymaster,Zod,,,,
+Erin Gilbert,,,Adult,8/4/2016 23:14:23,respectMyauthority@ghostbusters.ca,Plasma Town,Black Hole,Miigwetch,Doctor,Science,,,,
+Jillian Holtzmann,,,Adult,8/4/2016 23:15:59,lickmygun@ghostbusters.ca,Vortex,Astral Plane,Universe,The Best,Toys,,,,
+Patty Tolan,,,Adult,8/4/2016 23:17:23,HistoryGoddess@ghostbusters.ca,Subway,NYC,Planet Eart,Lesley,Jones,,,,
+Anthea Sykes,,,Child,8/4/2016 23:23:09,awful@sykesfamily.co.uk,An unnamed town,An unnamed county,England,"""Awful""",Sykes,,,,
+Oobedoob Benubi,,,First Worldcon,8/4/2016 23:31:22,Starfish1@domainname.fish,Springfield,Az,Usa,,,128,,,
+Boaty McBoatFace,,,First Worldcon,8/4/2016 23:45:32,marvinkmooney@pleasegonow.com,Kalamazoo,Timbuktu,Spam,,,,,,
+Sophie Meier,,,Youth,8/4/2016 23:47:12,sophia@zoeterwoude.nl,Leiden,Zuid-Holland,Nederland,Sophie,Meier,,,,
+Mario di Noble,,,First Worldcon,8/4/2016 23:48:20,Mario@whatever.joke,Pashmina,Indiana ,USA ,Mario,De noble,129,,,
+π∆q Bach,,,First Worldcon,8/4/2016 23:53:14,harpsichord@music.net,,,,,,,,,
+Pernickity Tests,,,First Worldcon,8/4/2016 23:59:10,pernickity@example.com,Pernickity,A pernickity place,Pernickity States of Acirema,Pernickity,Pernickityboots,130,,,
+Alan Diehl,,,Adult,8/5/2016 0:07:44,a.diehl@gnail.con,Double Trouble,NJ,USA,Al,Diehl,,,,
+FarkleBuns,,,Adult,8/5/2016 0:13:08,farklebuns@fakeip.net,Haad Yai,Songkhla,Thailand,Fred,Farklebuns,,,,
+Rock LeBateau,,,Adult,8/5/2016 0:25:16,Rock.LeBateau@gmail.com,Nottingham,Nottinghamshire,Great Britain (aka U.K.),Rock,LeBateau,131,,,
+Hypatia of Alexandria,,,First Worldcon,8/5/2016 0:49:00,nowhere@example.foiwr,Tycho Under,,Luna,Ann,Onyma,,,,
+Constitutional Crisis,Supporter,8/5/2016 0:51:15,,,thiswouldactuallywork@mailinator.com,New Paltz,New York,United States,Suzette,Smith-Singh,132,,,
+Metso Pekoni,,,First Worldcon,8/5/2016 1:14:51,pekoni.metso@gmail.com,Helsinki,Uusimaa,Finland,Metso,Pekoni,133,,,
+Jussi Halal-Aho,,,Child,8/5/2016 1:18:49,upponalle@gmail.com,Helsinki,Uusimaa,Isämmaa,Jussi,Halal-Aho,,,,
+Miles Vorkosigan,,,Adult,8/5/2016 1:21:54,Miles@vorkosigan.bar,Hassadar,Dendarii,Barrayar,Miles,Naismith,134,,,
+Gunnar Aasen,Supporter,8/5/2016 1:34:30,,,my@yes.no,Bergen,,Norway,Gunnar,Aasen,,,,
+Grynet Å,,,First Worldcon,8/5/2016 1:38:53,,Å,Lofoten,Norway,Grynet,Å,135,,,
+Khal Drogo,,,Kid-in-tow,8/5/2016 1:43:01,dothrakirulez@gmail.com,Horseback,Essos,Essos?,Khal,Drogo,,,,
+Colorful Designer,,,Adult,8/5/2016 1:51:36,dontyouwish@wiseass.com,Colorful,Colorado,U.S.A.,Colorful,,136,,,
+Bill Bogus Weinberg,,,Adult,8/5/2016 1:52:37,bogus@cloud13.net,Bronx,NY,United States,Bogus,Claret,137,,,
+Segreta Castro,Supporter,8/5/2016 1:54:26,,,segreta@bogus.org,Brooklyn,NY,United States,Mysteria,Z,,,,
+Alan Fakir Smithee,,,First Worldcon,8/5/2016 1:56:48,asf@bogus.org,New York,NY,United States,Fakir,Q,,,,
+J.M. McDoodle-o'wampus,,,Child,8/5/2016 2:11:56,Ddd@,Alton on Green Homeland ,Misisippi,U.s.a,Folgelblastervistacondragonpottlespudwumpusjoe,D,138,,,
+Řehoř Vaňčík,,,Adult,8/5/2016 2:16:11,janvanek.cv@gmail.com,Praha,,Czechia,Řehoř,Vaňčík,,,,
+Bilbo Baggins I,,,First Worldcon,8/5/2016 2:18:22,bilbo@theshire.net,Hobbiton,The Shire,Middle Earth,Bilbo,Baggins,,,,
+Rev Byron Dingleblatt,,,Kid-in-tow,8/5/2016 2:41:50,@dding.a.malformed.address,Rutabaga,,Freedonia,Caractacus,,,,,
+Penn Gwyn,,,Adult,8/5/2016 2:51:28,penngwyn@gmail.com,Toronto,Ontario,CANADA,Trob,Exil,139,,,
+Natasha Yar,,,Kid-in-tow,8/5/2016 4:20:28,nyar@enterprise.net,Coalition,Cadres,Turkana IV,Tasha,Yar,140,,,
+Elizabeth Thrall,Supporter,8/5/2016 4:38:31,,,Dolly@aol.com,Heaven,PA,USA,Dolly,Thrall,,,,
+Natalie Mestecom,,,Adult,8/5/2016 4:54:26,nat.mestecom@aol.com,Wordpress,Somewhere where there's winter,USA,Natalie,Mestecom,,,,
+Katherine Astra,Supporter,8/5/2016 4:55:30,,,kat.astra@aol.com,Wordpress,"Somewhere cold, too",USA,Kat,Astra,,,,
+Graciela Fairbanks,,,Adult,8/5/2016 4:56:42,g.fairbanks@aol.com,Somewhere where people can have farms,Ohio!,USA,Gracie,Fairbanks,,,,
+Hana Takahashi,,,Adult,8/5/2016 5:02:26,hana.takahashi@castle.com,Uhhh not sure,Also unsure!,USA!,Hana,Takahashi,,,,
+Mira Addleton,,,Adult,8/5/2016 5:03:27,mira.addleton@castle.com,"Um, dunno",Sigh...dunno,USA!,Mira,Addleton,,,,
+Simian Smallsby,,,Adult,8/5/2016 5:32:07,Noone@nowhere.org,Sebastopol,RI,Gondwanaland,Misty,Ayes,,,,
+Rixenchanter,,,Adult,8/5/2016 5:35:04,Rixenchanter@world.c,West Freeport,Freeport,Antonia,Rix,Enchanter,141,,,
+Ricardo,,,Kid-in-tow,8/5/2016 5:35:57,Bleep@bloop.ca,Stratford-Upon-Avon,,Republic of Northern Ireland,Hamid,D'Sousa,142,,,
+Eve Dallas,,,Adult,8/5/2016 5:36:34,Edallas@nypsd.gov,Nooyawk,NY,Irish Republic,,Dallas,,,,
+Gggraaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaargh Snaaaaaaaaàãåâäæerf,,,First Worldcon,8/5/2016 5:40:23,Rrrgh@grrruph.org,Piltdown,Florida,.,Gràaâåäæaaaaaaaaaaaaaaaaaaaaaàaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaargy,Graaaaãåâaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaergh,143,,,
+Nudoru soss,,,First Worldcon,8/5/2016 6:03:30,Nudorusoss@nevermind.org,Sonora,Sleepyhead,Dreamland,Nudoru,Soss,144,,,
+Santa Clause,,,Adult,8/5/2016 6:40:25,sdkjfhalsdkjfhk@djhksdjhfksjdh.com,North Pole,Arctic Ocean,skjdhfskdjfhk,Santa,Claws,145,,,
+T. G. Writer,,,Adult,8/5/2016 6:44:56,tgwriter@gmail.com,Word Processor,Macintosh,Apple,TG,Writer,146,,,
+Tom of Finnair,,,Adult,8/5/2016 6:49:59,Tom@Finnair.com,Kaarina,Turku,Finland,Tom,,147,,,
+Nalle Puh,,,First Worldcon,8/5/2016 7:11:04,Nalle@pu.h,Kouvola,,Westeros,Nöle (Nalle),Puh,,,,
+Brittany Anne Bifftad,,,First Worldcon,8/5/2016 7:47:58,brittany@androbovine.com,The Glades,Tofftown,Luna,Britty,Bifftad,148,,,
+Drugged Out Zombia,Supporter,8/5/2016 8:00:31,,,doz@totallystoned.org,Weed,CA,USA,Druggo,Zombie,,,,
+Cihuapilli Apipiyalotzin,,,Adult,8/5/2016 8:01:49,CihAppip@gmail.com,NoPattiztlan,OZ,Fairy,Cihuapilli,Apipiyalotzin,149,,,
+Pier Gerlofs Donia,,,Adult,8/5/2016 8:56:48,FrisianRebelPirate@yahoo.com,Kimswerd,Friesland,Netherlands,Pier,Donia,,,,
+Moggie McGato,,,First Worldcon,8/5/2016 9:29:42,Cathouse@fakemail.com,Katzenburg,Felidae,Meow!,Moggie,McGato,150,,,
+Hideki Motosuwa,,,First Worldcon,8/5/2016 10:54:07,hideki.motosuwa@gmail.com,Tokyo,,Japan,Hideki,Motosuwa,151,,,
+Alex Woodley,,,Adult,8/5/2016 11:20:09,alex.woodley@example.com,Winchester,,England,Alex,Woodley,152,,,
+Poplock Duckweed,,,First Worldcon,8/5/2016 11:46:55,poplock@example.com,Pondsparkle,,Zarathanton,Poplock,Poplock,,,,
+Fred the Great,,,Youth,8/5/2016 12:22:19,fredthegreat@fakemail.com,Mars,Milkyway,Universe,Fred,the Great,153,,,
+Sheila,,,Adult,8/5/2016 12:23:19,someone@bigpond.net,Perth,Western Australia,Australia,Sheila,Docker,154,,,
+Biggs McPearsen,,,Child,8/5/2016 12:23:33,biggsyboo@fakemail.com,Undulasia,BC,Amenada,Biggsy,McPearsen,155,,,
+Helena Robertson,Supporter,8/5/2016 12:27:26,,,hrobertson@geocities.com,Bangor,Maine,USA,Helena,Robertson,,,,
+Tintin Windowes,,,First Worldcon,8/5/2016 12:27:33,snowy@tintin.com,Townsville ,Denial,Canadaustralia,Tintin,Windowes,,,,
+Frank Zappa,,,First Worldcon,8/5/2016 12:28:23,zappa@frank.com,caprica,aldur,zootopia,Frank,Zappa,,,,
+Ashley Williams,,,First Worldcon,8/5/2016 12:31:24,ashley.m.williams@edenprime.mil.sa,San Juan,Puerto Rico,USA,Ashley,Madeline,156,,,
+meow,,,Adult,8/5/2016 12:33:25,meow@meow.meow,meow,meow,meow,meow,meow,157,,,
+Stephanie Brown,,,Youth,8/5/2016 12:33:38,Spoiler@batgirl.com,Gotham,,United States,,,,,,
+Ian,Supporter,8/5/2016 12:34:02,,,Iandoodoo@fake.cum,Cheesusville,Venus,Potatopia,Johan,Bach,158,,,
+Blake Langsam,,,First Worldcon,8/5/2016 12:36:37,,Brooklyn,Ny,United States ,Blake,Lamgsam,159,,,
+Samwise Gamgee,Supporter,8/5/2016 12:36:45,,,thegardener@potatoes.net,Hobbiton,Westfarthing,Shire,,,160,,,
+Not Slim Shady,,,Kid-in-tow,8/5/2016 12:38:07,itotallyamthough@hmail.com,Mars,Olympus Mons,Mars,Slim,Shady,161,,,
+Gromble Smindgub,,,First Worldcon,8/5/2016 12:38:30,antimattereater@hotmail.com,Void,Bigger Void,Biggest Void,Fence,Post,162,,,
+Chloë Glass,Supporter,8/5/2016 12:38:46,,,explodingpinapples@hotmail.com,Shantalla,Galway,Ireland,,,163,,,
+Albus Percival Wulfric Brian Dumbledore,,,Adult,8/5/2016 12:45:49,iopen@the.close,Kings Cross,Hogwarts,Your Mom,Albus,Dumbledore,164,,,
+Jon Pertwee,,,First Worldcon,8/5/2016 12:47:48,definitely@email.com,london,ohio,china,sean,roberts,165,,,
+John Tapwaters,,,Adult,8/5/2016 12:50:59,drinkwater@tap.com,Wet City,stateofdecay,Wetlands,John,Tapwaters,,,,
+Arram Draper,,,First Worldcon,8/5/2016 12:51:58,arramdraper@google.com,gottingen,Lower Saxony,Germany,Numair,Salmalin,166,,,
+Ella Byrne,,,First Worldcon,8/5/2016 13:00:57,whatifitsreal@mail.com,Casablanca,Dude IDK,Moonland,Elgernon,Bond,167,,,
+"Misty McBubbles, Queen of the Moon",,,First Worldcon,8/5/2016 13:03:30,fiddledeedee@wonkafactory.com,Glasgow,Manitoba,Switzerland,Angelica,Snigglefritz,168,,,
+Mona Choudhury,,,Child,8/5/2016 13:07:09,Mona@spce.org.nz,Tiamat,Tangaroa,Tangaroa,Mo,Choudhury,,,,
+Eleven,,,Child,8/5/2016 13:11:42,E11e@hawkins.in,The Upsidedown,Indiana? I guess?,US,Eleven,What's a last name,,,,
+Leina Rofe,,,First Worldcon,8/5/2016 13:18:23,Leina.Rofe@magi.jevu.ac.ke,Jevus,,Kenaan,Leina,Rofe,169,,,
+Sessa Liandra,,,First Worldcon,8/5/2016 13:18:29,sessa.l@gmail.com,Hamburg,Hamburg,Germany,Sessa,Lia,,,,
+Morgana Nightflower,,,Adult,8/5/2016 13:19:53,morgana@ghostbusters.com,New York City,New York,Transylvania,Morgana,Nightflower,170,,,
+Testy McTestface,,,First Worldcon,8/5/2016 13:20:54,testy@testface.com,Testoma,OR,USA,Testy,McTestface,171,,,
+Hrothgar Gil,,,First Worldcon,8/5/2016 13:23:38,gil.gar@totesandemail.com,Moontopia,Yue,The Moon,Abili,Asherbanerpal,172,,,
+Anne Shirley,,,First Worldcon,8/5/2016 13:24:04,annelovesgables@gmail.com,Avonlea,Prince Edward Island ,Canada,Anne,Shirley,173,,,
+Rosalia Disodium,,,Adult,8/5/2016 13:31:52,Radio@immexes.com,Melbourne,VIC,Australia,Rosalia,Disodium,174,,,
+sans skeleton,,,Adult,8/5/2016 13:32:37,skelepun@undernet.ut,Snowdin,The Capitol,The Underground,Sans,Skeleton,,,,
+Joss Page,,,First Worldcon,8/5/2016 13:32:42,shinyexplodythings@spacedad.com,Seattle,WA,United States,Jocelyn,Page,,,,
+Lorem Ipsum,,,First Worldcon,8/5/2016 13:33:28,willthiswork@email.com,Sint-Niklaas,Oost-Vlaanderen,Belgium,Lorem,Ipsum,,,,
+Papyrus Skeleton,,,Adult,8/5/2016 13:34:06,thegreatpapyrus@undernet.ut,Snowdin,The Capitol,The Underground,Papyrus,Skeleton,,,,
+Alia Flitspitch,,,First Worldcon,8/5/2016 13:36:47,aliaflitspitch@captainamerica.com,Beirut,Beirut,Lebanon,Sokovia,Accords,175,,,
+Marly Kerrion,Supporter,8/5/2016 13:37:18,,,Marly.Kerrion@fake.com,Derpcity,Goofball,Hotmess,Marly,Kerrion,,,,
+Boaty McBoatface,,,Kid-in-tow,8/5/2016 13:39:44,,UK,,,Boaty,McBoatface,,,,
+Julia Carver,,,Adult,8/5/2016 13:41:12,j.carver@havenherald.com,Haven,Maine,USA,Julia,Carver,176,,,
+Betty Boop,,,First Worldcon,8/5/2016 13:43:08,boopboop@bedoop.com,Downtown,Toon Town,Merica,Betty,Boop,177,,,
+Gaia Iulia,,,Kid-in-tow,8/5/2016 13:51:55,athing@aplace.com,Atlantis,Artichoke,A Place,Gaia,Iulia,,,,
+Commander Shepard,,,First Worldcon,8/5/2016 13:52:02,dahcommandah@spectres.citadel.com,Edmonton,Alberta,Canada,Jane,Shepard,,,,
+Celine,,,First Worldcon,8/5/2016 13:53:52,C.baby95@aol.com,Pittsburgh,Pa,USA,CeCe,,178,,,
+Pepe le Mew,,,First Worldcon,8/5/2016 13:56:17,Bio@bs.com,Ouagadougou,Denial,Burkina Faso,The,Dude,179,,,
+The Acolyte of Roland Jarvis,,,Adult,8/5/2016 13:57:04,acolyte@enlightened.rocks,Enlightened Compound,California,United States,The,Acolyte,,,,
+Rosa Schlüpfer,,,First Worldcon,8/5/2016 14:00:02,rosaschluepfer@waescheleine.com,Wanneeickel,NRW,Netherlands,Rosa,Schlüpfer,,,,
+Shev Clancy ,,,First Worldcon,8/5/2016 14:00:24,clancy@world.con,Newcastle ,NSW,Australia,Shev ,Clancy,,,,
+Ryxl Ironheart,,,First Worldcon,8/5/2016 14:01:38,champion_ironheart@org.horde.gov,Orgrimmar,Durotar,Kalimdor,Ryxl,Ironheart,,,,
+Agatha Heterodyne,,,Adult,8/5/2016 14:02:13,Heterodyne@Mechanicsburg.org,Mechanicsburg,ARAD,ROMANIA,Agatha,Heterodyne,,,,
+Duke Crocker,,,First Worldcon,8/5/2016 14:05:47,crockerduke@gmail.com,Havene,Maine,United States,Duke,Crocker,180,,,
+Andrew Baker,,,First Worldcon,8/5/2016 14:14:13,whatever@fakemail.com,Denver,Colorado,US,Andrew,Baker,,,,
+Menachim Stilinski,,,First Worldcon,8/5/2016 14:35:11,m.a.s@gmail.com,Dordrecht,Zuid-Holland,The Netherlands,Michaelangelo,Dumoulin,,,,
+Sam Yao,,,First Worldcon,8/5/2016 14:35:45,operator@abeltownship.co.uk,Abel Township,Yorkshire,UK,Sam,Yao,181,,,
+Clare Fraser,,,Adult,8/5/2016 14:40:12,stonetraveler@ladybroch,Inverness,Lallybroch,Scotland,Claire,Fraser,182,,,
+Your face,,,First Worldcon,8/5/2016 14:42:34,How about no @ why,Cats,Narnia,Paris,,,183,,,
+John Moore,,,Adult,8/5/2016 14:48:08,john.moore@mailserver.com,Liverpool,Lancashire,United Kingdom,John,Moore,184,,,
+Lisa de Groot,,,Adult,8/5/2016 14:49:49,liesdeg@gmail.com,Schiedam,Zuid Holland,Nederland,Lies,de Groot,,,,
+Scarlett Bradley,,,Adult,8/5/2016 14:54:27,sb11fly@fake.com,Gary,Indiana,United States of America,,,,,,
+Titiana Wren,,,First Worldcon,8/5/2016 14:58:12,,Paris,,France,Grace,,185,,,
+Mitchell Connolly,,,First Worldcon,8/5/2016 14:58:49,eternaltime@hotmail.com,Toronto,Ontario,Canada,Mitch,Connolly,,,,
+Bacta Skirata,,,Kid-in-tow,8/5/2016 15:04:06,ct1776@mynockpodcast.hnt,Tipoca City,Tipoca Sea,Kamino,Bacta,Skirata,,,,
+Saoirse D'Arcy,,,Adult,8/5/2016 15:05:05,saoirse.darcy@gmail.com,Uxbridge,Ontario,Canada,Saoirse,D'Arcy,186,,,
+Locke Lamora,,,Adult,8/5/2016 15:05:38,whatabastard@perelandro.org,Camorr,Camorr,Camorr,Locke,Lamora,,,,
+Lorenzo von Matterhorn,,,First Worldcon,8/5/2016 15:05:52,lvm.beast@email.com,Whitsett,NC,United States,Lorenzo,von Matterhorn ,,,,
+Jean Tannen,,,Kid-in-tow,8/5/2016 15:07:26,tannen@perelandro.org,Camorr,Camorr,Camorr,Tavrin,Callas,187,,,
+Smits McGee,,,First Worldcon,8/5/2016 15:08:27,snorlax@yahoo,Chagrin Falls,Ohio,USA,Melisande,Shaharizi,,,,
+The Doctor,,,Adult,8/5/2016 15:08:49,wibbly-wobbly@tardis.com,The Capitol,Outer Gallifrey,Gallifrey,John,Smith,,,,
+Roland Deschain,,,Adult,8/5/2016 15:09:51,last.gunslinger@gilead.gov,,,,,,,,,
+Shadow Moon,,,Adult,8/5/2016 15:11:42,,,,,,,,,,
+Susannah Dean,,,Kid-in-tow,8/5/2016 15:12:21,,,,,,,,,,
+Eddie Deen,,,Adult,8/5/2016 15:12:54,,,,,,,,,,
+Jake Chambers,,,Youth,8/5/2016 15:13:35,,,,,,,188,,,
+Oy,,,Child,8/5/2016 15:14:32,dress,ity,ovince,untry,Oy!,Ambers!,,,,
+Not Boaty McBoatface,,,First Worldcon,8/5/2016 15:19:33,notboatymcboatface@fake.com,North,Pole,Algeria,Not,Face,189,,,
+Romana,,,First Worldcon,8/5/2016 15:25:49,Timelady@gallifreymail.com,Capitol City,Prydonia,Gallifrey,Romanadvoratralunda,,190,,,
+Potato McLoving,,,Child,8/5/2016 15:27:20,respectthis@beemail.com,The mythical city of Washington,California?,Germany,Hoffnung,Ui!,191,,,
+Janice Montgomery,,,Adult,8/5/2016 15:28:41,janielanie@live.com,Ho Chi Minh City,,Vietnam,Janice,,,,,
+Morty Yelnats,,,First Worldcon,8/5/2016 15:30:07,Mortyels@notarealemailserver.co,The Moon,,,Morty,Yelnats,192,,,
+Chet Flash,,,Kid-in-tow,8/5/2016 15:32:57,chetflash@charter.net,the moon,the moon,the moon,Chet,Flash,193,,,
+Kate Malcolm,,,Adult,8/5/2016 15:33:16,midevilbabe@btinternet.co.uk,Richmond-on-Thames,London ,United Kingdom,,,,,,
+Ember,Supporter,8/5/2016 15:35:30,,,Aydenalendil071@aim.com,Boise,Idaho,USA ,Jane,Doe ,,,,
+Abso Lutien,,,First Worldcon,8/5/2016 15:37:17,ALutien@no.com,Auckland,,New Zealand,Absol,Lution,,,,
+Mrowing Mrower,,,First Worldcon,8/5/2016 15:48:43,mmwatchasay@gmail.com,Bowster,California,USA,Mrowing,Mrower,,,,
+Robert'); DROP TABLE members;--,,,First Worldcon,8/5/2016 15:52:30,Bobby@fake.com,Oz,Oz,Over the rainbow,Bobby,Tables,194,,,
+MCsketti,,,Youth,8/5/2016 15:55:58,THisLOveHastaakkenCONtrolOFme@homtail.comb,A cardboard box,A larger cardboard box,A fucking massive cardboard box,Borg,Magorg,195,,,
+Zuppa di Day,,,Kid-in-tow,8/5/2016 15:59:53,Zdd@imaginaryrealms.net,Saskatchewan,Wherever Saskatchewan is...,Kyrgystan,Zup,Day,196,,,
+Meow Meowface,,,Adult,8/5/2016 16:02:44,meow@catsville.org,Purrfect Peeeeace,Catsholme,Cat-Holica,Meow,Meowface,197,,,
+Marian,,,Adult,8/5/2016 16:03:04,Me.com,Lothering,N/A,Gone,Marian,,198,,,
+Akhal-Teke,,,First Worldcon,8/5/2016 16:14:48,akhal@teke.com,Portland,Maine,USA,Akhal,Teke,199,,,
+Delta,,,First Worldcon,8/5/2016 16:15:12,Delta@projectfreelancer.mil,New Luxor,Eridanus II,Outer Colonies,Delta,Church,200,,,
+Ragnell Szeto,,,Youth,8/5/2016 16:18:54,Rszeto1987@webmail.com,Cairo,Illinois,USA,Ragnell,Smith,201,,,
+Lala Mc'Sparkle,,,Adult,8/5/2016 16:20:48,Ozonlimes@esther.org,Gibbsonville,IT,USA,,,,,,
+Maya Wiener,,,Child,8/5/2016 16:22:43,,,,,,,202,,,
+Charlotte the Spider,,,First Worldcon,8/5/2016 16:24:55,web@parlor.org,Old Farmstead,Towney Town,Old Timey America,Charlotte,Spider,203,,,
+Impala67,,,First Worldcon,8/5/2016 16:33:08,fake@fake-email.com,Lawrence,Kansas,USA,Dean,Winchester,,,,
+Jane Elisabeth Carson,,,First Worldcon,8/5/2016 16:34:17,jec@gmail.ca,Arva,Ontario,Canada,Jane,Carson,,,,
+Remin Baskavits,,,Adult,8/5/2016 16:34:53,Rbakavits@gmail.com,Stonyvale,WI,United States,Remin,B.,204,,,
+Tracy C. Tillman,,,First Worldcon,8/5/2016 16:43:28,TracyCTillman@armyspy.com,Tempe,Arizona,USA,Tracy,Tillman,205,,,
+Anaander Mianaai,,,Adult,8/5/2016 16:44:10,miannaaia@radch.gov,The Radch,Radch,Radch,Anaander,Mianaai,206,,,
+Anders And,,,Adult,8/5/2016 16:47:34,andersand@andersandmail.andeby,Andeby,Andeby,Andeby,Anders,And ,207,,,
+Highest Noon,,,Child,8/5/2016 16:48:48,Hanzo@McCree.bark,Yiffton,West Yaoi,Kinkistan,Tolta,Sirus,,,,
+Larry Butz,,,First Worldcon,8/5/2016 16:49:16,l.butz@fake.com,Cowton,Oregon,USA,Larry,B.,,,,
+David Washington,,,Adult,8/5/2016 16:52:47,agentwashington@projectfreelancer.com,Seattle,Washington ,USA,David,Washington,208,,,
+C. Niall D. Mentia,,,Kid-in-tow,8/5/2016 16:57:56,donald.trump@yiffyiff.constantly,Uranus,NSFW,anyGerm,Eyema,Faygit,209,,,
+Michael J. Caboose,,,Kid-in-tow,8/5/2016 17:03:06,Churchismybestfriend@basebook.com,The moon,Still the moon,Earth,Michael,Caboose,210,,,
+Count Petyr Bezukhov,,,Adult,8/5/2016 17:04:13,Napoleancanbiteme@gmail.com,Moscow,Russia,Russia,Pierre,Bezukhov,,,,
+Marie Wolfe,,,Adult,8/5/2016 17:15:09,mizzwolfe@fakey.com,Kitchissippi,Iowa,USA,Marie,Wolfe,,,,
+Brontus McMiller,,,First Worldcon,8/5/2016 17:24:32,jackedupsoupedup@hotmail.com,Dubai,Dubai,,,,211,,,
+W.H.Oami,,,Adult,8/5/2016 17:25:55,Falsified@faaified.com,Yorick,Yorickshire,Yorickson,Q,Jepson,212,,,
+Amanda Hugginkiss,,,First Worldcon,8/5/2016 17:26:54,ahk@example.com,Fauxington,NW,US,Amanda,,213,,,
+Sherlock Beeblebrox,,,Youth,8/5/2016 17:27:09,supercalifragilistic@aol.com,Ankh-Morpork,Ankh-Morpork,Discworld,Albert,Hall,,,,
+Hugo Second,,,First Worldcon,8/5/2016 17:28:39,h2nd@overcliffe.net,Sun City,Wiltshire,UK,Hugo,Second,214,,,
+Lauren Ipsum,,,Kid-in-tow,8/5/2016 17:30:17,Lauren.Ipsum@Dolor.sit,221B Baker Street,PA,Camelot,Lauren,Ipsum,215,,,
+Jane Doe,,,Kid-in-tow,8/5/2016 17:32:03,janedoes@gmail.com,Nowhere,Oregon,USA,Jane,Doe,216,,,
+James T. Kirk,,,First Worldcon,8/5/2016 17:32:06,j.t.kirk@enterprise.starfleet,Cornfed,Iowa,The Final Frontier,Captain,Kirk,,,,
+Arthur Pendragon,Supporter,8/5/2016 17:33:37,,,TheOnceandFutureKing@camelot.co.uk,Avalon,Wales,Camelot,Gwydion,Ectorson,217,,,
+Hiccup Horrendous Haddock III,,,Kid-in-tow,8/5/2016 17:34:23,Hiccup@berk.bk,Berk,Berk,the Barbarous Archipelago,Hiccup,Stoicksson,,,,
+Spock,,,Adult,8/5/2016 17:35:32,spock@enterprise.starfleet,Vulcan,T'Khar,Vulcan,Spock,You couldn't pronounce it,,,,
+Peanut Disarien,,,First Worldcon,8/5/2016 17:36:41,butternut@pmail.com,athabaski,whashinigan,matteri,Pea,Disi,218,,,
+Jack Bruce,,,First Worldcon,8/5/2016 17:40:14,THIS IS A FAKE EMAIL,London,,England,Jack,Bruce,219,,,
+Ms. Tiggie Terrible,,,First Worldcon,8/5/2016 17:49:36,donotusethis@gmail.com,Ridgefield Park,NJ,USA,Ti,Terrible,220,,,
+Merlin Emrys,Supporter,8/5/2016 17:53:57,,,"Arthur's quarters, the Citadel",The Citadel,Camelot,Camelot,MERlin,Emrys,221,,,
+John Watson,,,Adult,8/5/2016 17:55:23,Johnwatson@memail.co.uk,London,Central,UK,John,Watson,,,,
+Doctor Who,,,Adult,8/5/2016 17:56:17,thedoctor@tardis.gallifrey,all of them,all of them,all of them,The Doctor,"No, just ""The Doctor""",,,,
+Zaphod Beeblebrox III,,,First Worldcon,8/5/2016 18:02:51,zaphod@yowza.com,Mandalor,,,Zaph,Baby,222,,,
+Budworth Barclay,,,Kid-in-tow,8/5/2016 18:16:08,,Albany,New York,Finland,Bud,Jefferson,,,,
+Brooke Wyles,,,Adult,8/5/2016 18:19:42,bwyles@email.com,Los Angeles,California,USA,Brooke,Wyles,,,,
+Elodie Sinclair,,,First Worldcon,8/5/2016 18:21:06,ElodieEss@Hotmail.com,Montreal,Quebec,Canada,Elodie,Sinclair,223,,,
+Eleven,,,Child,8/5/2016 18:22:34,SecretlyYoda@gmail.com,What do you mean,This isn't Maine,United States,Eleven,,,,,
+I-have-no-mouth-and-i-must-scream Connors,,,Kid-in-tow,8/5/2016 18:23:33,yesjustlikethesouldevouringattheendoftheworld@planeteatersanonymous.whatno,Room 234876B,Tafanda Bay,Ithor,I-have-no-mouth-and-i-must-scream,Connors,224,,,
+Emily Campbell,,,First Worldcon,8/5/2016 18:35:36,ecampbell@hogwarts.com,Kiel,Schleswig-Holstein,Germany,Emily,Kampbell,225,,,
+Eloise Eloquent,,,Adult,8/5/2016 18:43:36,Eeee@email.com,Nebraska,Nova Scotia,Deutschland,Esiole,Tneuqole,226,,,
+Spock Smith,,,First Worldcon,8/5/2016 18:58:48,spock@enterprise.com,Shikar,Star City,Vulcan,Spock,Smith,,,,
+SADIE HALFTALL,,,Kid-in-tow,8/5/2016 19:00:03,Sadie@dragonmail.com,The lair of the dragons,What part of the lair of the dragons didn't you get?,Wherever the lair of the dragons is.,Sadie,Brass,,,,
+Sassy T. Cat,,,First Worldcon,8/5/2016 19:02:23,furball@catnip.com,Farmville 2,Moosylvania,US,Sassy,Cat,227,,,
+Bendydoink Catsinpants,,,Kid-in-tow,8/5/2016 19:02:49,bcatsinpants@yourchimney.org,Abu Dhabi,The World,The Milky Way,Ben,Cats,,,,
+Melody Goldstein,,,Adult,8/5/2016 19:03:00,sukadogdik@aol.com,Kansas City,Nebraska,Unites States,Melody,Goldstein,,,,
+Sifu Hotman,,,First Worldcon,8/5/2016 19:04:45,sifu_hotman@fakemail.com,Ba Sing Se,Earth Kingdom,Earth Kingdom,Sifu,Hotman,228,,,
+Samuel,,,Adult,8/5/2016 19:05:01,samuel@noneofyourbusiness.com,Chicago,Illinois,Usa,Samuel,Samuelson,229,,,
+Bobby Newport,,,Adult,8/5/2016 19:10:29,hasneverhadarealjob@inhislife.com,Pawnee,Indiana,US,Bobby,Newport,230,,,
+Taco McBell,,,Adult,8/5/2016 19:21:16,goose@gaggle.com,,,,Taco,McBell,231,,,
+Donald Doodyhead,,,First Worldcon,8/5/2016 19:25:03,donalddoodyhead@msn.com,NYC,NY,USA,Donnie,,,,,
+Edna Edelweiss ,,,Adult,8/5/2016 19:29:12,floraflower09@gmail.com,Margaritaville ,Florida,USA,Daisy,,232,,,
+Mat Cauthon,,,First Worldcon,8/5/2016 19:29:50,Luckypips7@gmail.com,Emond's Field,PA,USA,Knotai,Cauthon,,,,
+Ogdor,,,Kid-in-tow,8/5/2016 19:34:41,What?,North York,South York,New Carolina,The Great,And Powerful,233,,,
+OohAah Cantona,,,Youth,8/5/2016 19:37:23,canolisarealright@intaliano.com,Piza,,Italy,OohAah,Cantona,,,,
+Ashton Howerton,,,Child,8/5/2016 19:52:19,Ashho@gmail.com,Lilith,New York,America,Ashton,Howerton,,,,
+"Gorblaxis Slaglon, King of Gamma VII",,,Kid-in-tow,8/5/2016 19:52:32,EarthConquerer@gorblaxiaplaza.gov,New York City (Soon to be renamed Gorblaxia II),New York,United States,Doom,Bringer,234,,,
+Chet Gladstones,,,Adult,8/5/2016 20:00:45,frutieprincessbubblegum@gmail.com,Hell,Michigan,USA,Charles,Happypebbles,235,,,
+Ryba McNuggins,,,Kid-in-tow,8/5/2016 20:06:16,Squishly@zorg.com,La Luna,Ourkansas,Canana,Georgous,Strigling,,,,
+Izzy Ruto,,,First Worldcon,8/5/2016 20:28:14,izzy.ruto@gmail.com,Mobile,Alabama,United States,Isabella,Ruto,,,,
+Margot Empress Of Destruction,,,First Worldcon,8/5/2016 21:08:15,12345@fakeemal.cob,Iacon,Manganese,Cybertron,Jane,Doe,,,,
+Dave Strider,,,Youth,8/5/2016 21:30:20,turntechgodhead@cool.com,not the fucking meteor anymore,idek anymore,the current universe,Dave,Strider,236,,,
+Alex Colin Stewart,,,Youth,8/5/2016 21:32:30,,San Fransisco,California,America,Alec,Stewart,237,,,
+Kathryn Janeway,,,Adult,8/5/2016 21:36:02,kathryn.janeway@voyager.mail,Voyager,Delta Quadrant,Space,Kathryn,Janeway,,,,
+Titty Malasyia,Supporter,8/5/2016 21:37:59,,,orphan.black@gmail.com,Scarborough ,Toronto,Canada,Titty,Malasyia ,,,,
+👽👭😍🌌,,,Youth,8/5/2016 21:43:13,👽👭😍🌌,👽👭😍🌌,👽👭 😍 🌌 ,👽 👭 😍 🌌 ,👽 👭 😍 🌌 ,👽 👭 😍 🌌 ,238,,,
+Dairine Callahan,,,Youth,8/5/2016 21:45:59,dari@worldsend.co,Long Island,NY,USA,Dari,Callahan,239,,,
+Разбойник Бармалей,,,Adult,8/5/2016 21:57:02,barmaley@mail.chu,Джунгли,Лимпопо,Занзибар,Бармалей,Разбойник,,,,
+Kalessin Prrrrrer,,,First Worldcon,8/5/2016 22:10:10,kitten@mau.pr,Kastrop-Rauxel,NRW,Germany,Kali,Cat,240,,,
+Gilbert Forthright,,,Child,8/5/2016 22:22:27,Gilbertthegrape@communistconspiracy.com,Buenos Aires,,Sokovia,Hortense,Puddlington,241,,,
+Lucia Marino,,,Adult,8/5/2016 22:35:31,lucia.marino@paladino.es,Charouse,Villanova Ile,Vodacce,Lucia,Marino,242,,,
+Jubilation Lee,,,First Worldcon,8/5/2016 22:40:57,jubilee@xavier.edu,New York City,NY,USA,,,243,,,
+El Fake-o Name-o,,,First Worldcon,8/5/2016 23:20:17,1234 Any Street,Hometown,DC,USA,Anonny O,El Name-o (Bingo),244,,,
+Rose Marian Day,,,First Worldcon,8/5/2016 23:20:55,rmday@gmail.com,Exeter,New Hampshire,United States of America,Rose,Day,,,,
+❆,Supporter,8/5/2016 23:24:10,,,a@b,Espero Urbo,Ĉi tie,Esperantolando,☜☝☞☟,,245,,,
+Meranna di Cantos,,,First Worldcon,8/5/2016 23:46:43,meranna_di_cantos@mileth.net,Mileth,Rucesion,Temuair,Meranna,di Cantos,246,,,
+Reginald Sinclair,,,Adult,8/5/2016 23:56:13,reginald_+finland@catbus.co.uk,Manchester,Manchester,England,Reggie,Spectrum,247,,,
+Txhmamiqat atarsalkamoxh,,,First Worldcon,8/6/2016 0:04:31,pxhatmar@kusaq.tx,Dallas,TX,United States,Itiraq,,,,,
+Hayden Kensington,,,First Worldcon,8/6/2016 0:16:36,mail@fakeemail.com,Broomfield,Wisconsin,United States of Hilarity,Kendra,Smith,,,,
+Isgebind,,,Kid-in-tow,8/6/2016 0:17:25,indolent@me.com,Groovytown,RI,USA,Meg,Murray,248,,,
+Not Batman Obviously ,Supporter,8/6/2016 0:35:34,,,Nbo@elsewhere.com,The Base,The Moon,Space,Not,Obviously ,,,,
+Kethrys,,,Kid-in-tow,8/6/2016 0:50:30,Kehthxs@hyosmil.com,Sparta,Alberta,Canada ,Josie,McDonald,249,,,
+Stella Kui,,,Youth,8/6/2016 1:05:32,fornlets1950@jourrapide.com,"Los Angeles, California",California,United States,,,,,,
+Rowan Sunchild,,,Adult,8/6/2016 1:18:18,albacore@deepsea.net,Golden Lake,Yukon Territory,Canada,Jo,Billingsworth,250,,,
+Lulu,,,Child,8/6/2016 1:26:11,luluandromedadestroyerof@worlds.com,The moon,Solar System,Milky Way,THE lulu,None of your beeswax ,,,,
+Peri,,,Kid-in-tow,8/6/2016 1:31:12,Peri.dot@gmail.com,Pflugerville,Texas,UAE,Peri,Dot,,,,
+Donglord McSucc,Supporter,8/6/2016 1:45:53,,,albanybaster@mrrrrrrrrr.com,The Moon,Down South,This period -->.,JOHNNNNNNN ,cena.,251,,,
+Ekatarin Vorkosigan,,,Kid-in-tow,8/6/2016 2:03:22,gardencat@hassadar.edi,Vorbarr Sultana,Vorkosigan ,Barrayaran Empire,Ekaterin,Vorkosigan,,,,
+Bob,,,First Worldcon,8/6/2016 2:03:34,boop@beep.com,Vorkosigan,WY,Andorra,Frederick,Kruger,252,,,
+Sara martignone,,,Youth,8/6/2016 2:46:10,sara.m.90@gmail.com,Jujuy,Jujuy,Argentina,Sara,Martignone,,,,
+Kade Kennedy,,,Adult,8/6/2016 3:03:23,Rikroll@otherworlds.com,Riverside,Mo,USA,Georg,Handel,,,,
+Gerry James,,,Youth,8/6/2016 3:21:45,Gerryjames4678425098813@gmail.com,San Francisco ,California ,United States,Gerry,James,253,,,
+Supreme Leader Kim Jong Un,,,First Worldcon,8/6/2016 3:26:31,kimjongun@northkorea.com,Pyongyang,,North Korea,Kimmy,,254,,,
+Wilhelmina Iggleswoop,,,Adult,8/6/2016 3:27:50,WI@london.ig,Uberchester-on-the-Slope,Undershire,UK,Willie,Iggleswoop,,,,
+Lemons McLemons,,,First Worldcon,8/6/2016 3:52:06,lemons@lemons.lemons,Lacus Somniorum,Isternes,The Moon,Lemons,Ransom,255,,,
+Peppermint Bunny,,,Adult,8/6/2016 4:11:54,pepperbun@hutch.net,Carrottown,New Burrow,Fursylvania,Pepper,Bun,,,,
+Pack Hunt,,,Kid-in-tow,8/6/2016 4:15:56,packsaplenty@imgonnahowllots.wolf,Gruul,Ravnica,Dominaria,Squanchum,Hunt,256,,,
+Adán Najera,,,Kid-in-tow,8/6/2016 4:17:32,grizzlycudlebear@yahoo.com,Bear Town,Ursus Land,Bear Den,Dan,Naj,257,,,
+Garnet McBadass,,,Adult,8/6/2016 4:26:42,butterycupcakes@nomail.com,Jupiter,Norway,Gemworld,Meredith,Snailslayer,258,,,
+Alfred E. Neuman,,,Adult,8/6/2016 4:40:46,Yahoo@mad.com,Brooklyn,New York,USA ,Alfie,Neuman,259,,,
+One Entire Succ,,,Youth,8/6/2016 4:45:24,dat_boi@succ.com,,,Succland,,,,,,
+Cider Ilohas,,,First Worldcon,8/6/2016 4:51:33,tennen@brop.com,Boring,Oregon,USA,,,,,,
+Pepe Scoober,,,Child,8/6/2016 5:01:57,ohshit@scooby.me,Gaytown,Boom,Nanaland,Doofus,Boofer,,,,
+Frau Doktor Worblehat,,,First Worldcon,8/6/2016 5:13:22,fraudoktor@unseenuniversity.edu,Ankh-Morpork,The Left Side,Diskworld,Frau,Worblehat,260,,,
+Ariane Chodkow,,,First Worldcon,8/6/2016 5:26:33,achod@gmoil.com,Woodrowburg,CA,US,Ariane,Chodkow,,,,
+Duke Hardcastle,,,First Worldcon,8/6/2016 5:31:07,hcastle@msn.com,Waukesha,WI,USA,Duke,Castle,,,,
+Annabelle Dierett,,,First Worldcon,8/6/2016 5:51:26,annabelle@terran.edu,Laguna Garden,Mainland,Taeat,Annabelle,Dierett,261,,,
+Aarti Skywalker,,,Adult,8/6/2016 6:45:12,polgarathesorceress@gmail.com,Tokyo,Zurich,Australia,Ellariayn,Weatherwax,,,,
+Amy Salmonhead,,,Kid-in-tow,8/6/2016 7:19:06,iamnotedible@gmail.com,Santa's Village,Alabama,United States,Amy,Salmonhead,,,,
+Maria Turnbull,,,First Worldcon,8/6/2016 7:27:33,m4ria.turnbull23@gmail.com,Auckland,,New Zealand,Maria,Turnbull,262,,,
+Jayden Starstorm,,,First Worldcon,8/6/2016 8:28:57,jaydensthebestalwaysforever@myemail.com,Pittsburgh,Jersey,Somerset,Starstorm,Jayden,263,,,
+Julia Belvedere,,,First Worldcon,8/6/2016 8:36:52,,Topeka,Kansas,United States,,,264,,,
+Clarice Starling,,,First Worldcon,8/6/2016 8:51:37,clarice@fakeemail.com,nowhere,new narnia,further up and further in,Callie,Star,265,,,
+Tony Stark,,,Adult,8/6/2016 10:31:26,Stark@stark.com,Malibu,California,Usa,Tony,Stark,,,,
+Pete Zahut,,,First Worldcon,8/6/2016 18:52:22,petezahut@fakeaddress.suk,Barsoom,Hy,Madagascar,Pete,Zahut,,,,
+Rick Jones,Supporter,8/6/2016 19:09:08,,,rickjones@sidekicks.com,Scarsdale,Arizona,USA,The,Whisperer,,,,
+Temeraire,,,First Worldcon,8/6/2016 19:14:36,temeraire@aerialcorps.mod.uk,Loch Laggan (it rhymes with my species),,Scotland,,,,,,
+BoomShakaLaka,Supporter,8/6/2016 19:30:20,,,bigbang4eva@topsmassivebulge.woah,Your Face,Fantastic Baby,Random park bench,Boom,ShakaLaka,,,,
+Nimps,Supporter,8/6/2016 19:36:07,,,niimps@silverline.net,Milwaukee,Nebraska,Georgia,Temperance,Cuervo,266,,,
+Esteban Morolonion,,,Child,8/6/2016 19:59:33,kjsadf@lskdjfa,Kingdom in the Mists,Windermere,Wild West,King Gilead,Windermere,,,,
+Eblis O'Shaunessy,,,Adult,8/6/2016 20:09:53,eblis@aol.com,Hades,Elsewhere,Mootopia,Ebbles,Oshun,,,,
+Fairest and Fallen,,,First Worldcon,8/6/2016 22:20:28,theothersideoftheuniverse@tptb.wizardry ,NYC Alternate Universe,NY,Timeheart,Lone,Power,267,,,
+Arcflash Watts,,,Youth,8/6/2016 23:10:26,arcflash@melancholyhill.talent,New York,New York,United States of America,Arcflash,,268,,,
+Memory Greycat,,,First Worldcon,8/6/2016 23:27:55,memory@thegrey.cat,Meh,Maune,United Siamese Adults,Grey,Cat,269,,,
+Dude McPherseon-Plantaganet,,,Adult,8/6/2016 23:37:17,mcpherse@btu.edu,Lodgepolis,Montana,United States of AMERICA ,Dude ,Lodgepolitian,270,,,
+Alice The Horse,,,First Worldcon,8/6/2016 23:42:25,alicethehorse@yandex.com,Steveston,Massachusetts,U.S.,Alice,Offbrand Amish,,,,
+Sally-May,Supporter,8/6/2016 23:48:26,,,Salliemae@shady.gov,Newark,Delaware,U.S.A.,Sallie,Banker,271,,,
+Adam Young,,,Youth,8/6/2016 23:55:16,adamyoung@stopmessingaroundinpeople'slives.net,Lower Tadfield,Oxfordshire,Unseceded Britain,Adam,Young,,,,
+Declan Dublin,,,Adult,8/7/2016 0:01:32,PorkyPig69er@hotdawg.du,Helsinki,Baconshire,Un-united Kingdom,I Really Like the Letter,WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW,272,,,
+Fake Bill,Supporter,8/7/2016 0:22:23,,,disposable+tag@fastmail.fm,Croton-on-Hudson,NY,USA,Still Fake,Nielsen Hayden,,,,
+Marsh Skatekey,,,Kid-in-tow,8/7/2016 0:27:49,i'llrootfortheoilersifiwantgetoffmycase@hotmail.com,Rainy River Dist.,Ontario,Canada,Shep,The Ex-Shepherd,273,,,
+Spodo Komodo,,,First Worldcon,8/7/2016 1:07:41,s.komodo@goat.com,Limerick,,Eire,Spodo,Komodo,,,,
+Superfly McDr,,,Adult,8/7/2016 3:21:25,pinthis@hotstuff.net,Normal,IL,USA,Super,McDr,274,,,
+Meadow Lark,,,First Worldcon,8/7/2016 3:38:32,Mlark@umail.com uwu,BOSS TOWN (ﾉ≧∇≦)ﾉ ﾐ ┸━┸,Massachussetts,U!S!A!,Meadow,,,,,
+Bella Fuga,,,Adult,8/7/2016 4:56:41,genericemail@yahoo.com,Boring,Oregon,USA,,,,,,
+Jimmy); DROP TABLE Members; --,,,First Worldcon,8/7/2016 5:25:31,jimmy@abl.es,Oxford,Oxfordshire,Earth,jimmy,tables,275,,,
+Abby Stonebender,,,First Worldcon,8/7/2016 7:06:54,beauregard21@hotmail.com,Toledo,Ohio,USA,Abby,Stonebender,,,,
+Helena Morgan,,,Adult,8/7/2016 8:37:05,this.is.legit.fake+extrastuff@example.com,Omelas,Uncertainty,Earth,Helena,,,,,
+Swagamoto,,,First Worldcon,8/7/2016 8:39:04,swagamoto@hotmail.com,Swagville,Swag County,Swaglandia,Swagamoto,Swagamoto,276,,,
+Sauce,,,Adult,8/7/2016 8:43:47,sauce_uke@gmail.com,Konohagakure,Konohagakure,Hi no Kuni,Sasuke,Uchiha,277,,,
+L,,,Kid-in-tow,8/7/2016 8:46:36,lllowlight@hotmail.com,Secret,N/A,SECRET,L,L,278,,,
+Harry BWL Potter,Supporter,8/7/2016 8:51:13,,,treacletreacletreacletart@gmail.com,NOT Surrey,,The No Longer United Kingdom of Great Britain and Northern Ireland (Thanks a Million Brexit),Harry,Potter,279,,,
+Speshul,,,Youth,8/7/2016 8:53:50,speshulsnowflake@msn.com,Tumblrton,New Tumblr,Tumblria,Speshul,Snowflake,280,,,
+Yaoirox,,,Adult,8/7/2016 8:55:49,yaoirocrokroxomgz@gmail.com,Yaoiiiiiiiiiii,Roxxxxxxx,Yaoiroxland,Yaoifan,Yaoirox,,,,
+Ash Ketchup,Supporter,8/7/2016 8:58:09,,,pokemongoz@gmail.com,Pallet Town,Kanto,Pokeworld,Ash,Ketchup,281,,,
+Åäö ÅåÄäÖö,,,Child,8/7/2016 10:09:33,åäö@öö.åå,Åland,,Öland,Å,Ö,282,,,
+"de Havílland, John",Supporter,8/7/2016 10:12:38,,,jdh@jdh.is.not,Lüxembørg,,Ærland,John,de Havílland,,,,
+James Arthur Saville,,,Adult,8/7/2016 12:17:22,SirJimmy@saville.org.uk,Brummieland,Nonceville,UK,Sir Jimmy,Saville,,,,
+hnreaz vtr68iuvc,,,First Worldcon,8/7/2016 14:43:21,hnu5ipq-bmrie90+,ohio,ohio,ohio,bcftr,cty,,,,
+Ture Storm,,,First Worldcon,8/7/2016 15:04:25,turestorm@fandom.org,Stockholm,,Sweden,Ture,Storm,283,,,
+"Catherine the Gray of House Pendragon, De-feeter of Buggies and Lord of the Underbed",,,First Worldcon,8/7/2016 15:53:11,CTG@fakemail.com,Underbed,Pennsylvania,USA,Cat,Pendragon,,,,
+Laurel Kay Pendragon,,,First Worldcon,8/7/2016 16:03:45,onetwothree@bob.com,Emerald City,PA,USA,Kay,Pendragon,,,,
+Dr. John Smith,,,First Worldcon,8/7/2016 21:32:31,Doctor@tardis.sp.mil,The Barn,The Citadel,Gallifrey,John,Smith,284,,,
+David Bowie,Supporter,8/7/2016 22:44:27,,,Spaceman@wtf.fashion,Brixton,London,England,Ziggy,Stardust,,,,
+ —,,,Child,8/8/2016 5:54:29, , , , , , ,,,,
+        @,,,Child,8/8/2016 5:55:33,,,,,,,285,,,
+Jack Rabbit,,,Kid-in-tow,8/8/2016 6:43:25,secretylajackalope@horns.net,Kansas City,MO,USA,Jack,Rabbit,286,,,
+Taliesin Locke,,,First Worldcon,8/8/2016 9:56:56,taltale92@gmail.com,Vedado,Havana,Cuba,Tali,Locke,,,,
+Radomir Meleg,,,Adult,8/8/2016 16:39:31,radma@hum-szeged.hu,Szeged,,Hungary,Radomir,Meleg,287,,,
+Loránd Eötvös,,,First Worldcon,8/8/2016 17:06:59,derboss@eeltee.hu,Budapest,,Hungary,Loránd,The Man,,,,
+Honesty Masters ,,,Child,8/8/2016 17:29:13,kelpietickler@hotmail.com,Salt Lake City,Utah,USA,Sillimos,,,,,
+Richard Tuukc,Supporter,8/8/2016 17:53:03,,,,,AK,USA,Rick,,288,,,
+Elena Shvarts,,,Adult,8/8/2016 18:03:54,,St. Petersburg,Leningradskaya Oblast',Russian Federarion,Lena,Shvarts,289,,,
+Jolana Popović,Supporter,8/8/2016 18:36:32,,,jolana.popovic@zemunjezakon.rs,Beograd,,Serbia,Jo,Popović,,,,
+Lindsay James,,,First Worldcon,8/8/2016 21:42:34,mcpoodle.doodle@aol.com,Philadelphia,PA,United States,Lindsay,James,290,,,
+drop table;,,,Adult,8/8/2016 22:03:31,drop table;,drop table;,drop table;,drop table;,drop table;,drop table;,291,,,
+James Bond,,,Adult,8/9/2016 5:55:55,007@mi6.gov.uk,classified,classified,England,James,Bond,,,,
+Slatribartfast albus hinikin iii,,,First Worldcon,8/9/2016 8:10:11,embaressingusername25@angelfire2.com,Norway,ohio,america of the north,bart,hinikin,292,,,
+Slipnotika Kornilia Edgelord,,,Youth,8/9/2016 8:19:25,Thereisnonemoreedge@razor.com,blackwall ,edgess,Noirvania,Knottikorn,Edgelord,,,,
+Person Unusual,,,First Worldcon,8/9/2016 18:23:55,person@person.org,Atlanta,KS,USA,Person,Person,293,,,
+Claire Dale,,,First Worldcon,8/10/2016 1:11:51,clairedale92@yahoo.com,Cedar town ,Georgia ,America,Claire,Dale,294,,,
+"Ponsonby Britt, O.B.E.",,,First Worldcon,8/10/2016 9:28:42,ponsonby@britt.obe,Mafeking,,Transvaal Colony,Ponsonby,Britt,295,,,
+Horatio Xavier Taylor-Smith,,,Adult,8/10/2016 17:58:23,h.xavier.taylor-smith@gmail.com,Juarez del Norte,Texas,USA,Xavier,Taylor-Smith,,,,
+Geo-Rge Jetson,,,First Worldcon,8/13/2016 1:18:11,123@CBSOUTDOOR.com,St Louis,MO,USA,Geo-Rge,Jeston,,,,
+Julian Nebogipfel,,,Adult,8/13/2016 23:49:29,alpha.ralpha@boule.com,Deep Space,Gilead,Fandom,Julian,Julian,,,,
+Ash Ketchum,,,Youth,8/14/2016 7:56:13,catchemall@pallettown.kn,Pallet Town,Kanto,Kanto,Ash,Ketchum,296,,,
+Kalani The Parrot,,,First Worldcon,8/15/2016 1:27:32,,Alexandria,,Egypt,Kalani,Kalani,,,,
+Ginger Johnson,,,First Worldcon,8/15/2016 1:35:11,pematson@yahoo.com,Rochester,NY,US,Snaps,Johnson,297,,,
+Sally Park,Supporter,8/15/2016 1:37:32,,,pematson@yahoo.com,San Francisco,Calif.,USA,Sally,Park,,,,
+Tilda Gelhorn,,,First Worldcon,8/15/2016 1:41:29,pematson@yahoo.com,,,,Tilda,Gelhorn,298,,,
+Princess Ariadne,,,Youth,8/15/2016 1:45:49,,Knossos,Crete,Crete,Princess,Ariadne,299,,,
+Jill Highsmith,Supporter,8/15/2016 1:52:09,,,jhighsmith@nationalparks.uk.gov,Windermere,Cumbria,England,Jill,Highsmith,,,,
+Robin Williamson,,,First Worldcon,8/15/2016 4:08:43,palmtrees@grimace.com,Salem,Massachusetts,United States,Robin,Williamson,300,,,
+Anna,,,Adult,8/15/2016 19:15:48,Please.best@yahoo.org,East Jordan,MI,America,Mickey,I,301,,,
+Mijn echte Foute Naam,,,First Worldcon,8/17/2016 11:53:20,Ikke@amsterdam.nl,Amsterdam,Noord Holland ,The Netherlands,I ,Amsterdam,302,,,
+Tellu Tyllönen,,,Adult,8/20/2016 11:52:18,tellu.tyllonen@jossain.com,Kemijärvi,,Finland,Tellu,Tyllönen,,,,
+Ta-Neisha Wu,,,Kid-in-tow,8/23/2016 7:10:59,taneisha@gmail.comm,Newark,NJ,USA,Ta-Neisha,,,,,
+Alys Moggie Catnip,,,Kid-in-tow,8/24/2016 3:13:49,AMog@FakeMail.com,Purrsepolis,Fursylvania,Catatonia,Alys Moggie,Catnip,,,,
+Arabella Ashby,,,First Worldcon,8/24/2016 3:34:00,A.Ashby@Diana.MarsTrading.Com,Woodthrush Woods,Fort Augusta,Mars,Arabella,Ashby,,,,
+Keeler Altair,,,First Worldcon,8/26/2016 1:15:01,k.altair@battle.ship,None,None,Alternia,,,303,,,
+Anastasia Sÿms,,,First Worldcon,8/29/2016 4:15:38,011110@jeep.com,Holland,Michigan,US,FanGrrrl,,304,,,
+Meep Newton,Supporter,8/29/2016 4:17:25,,,Meep@gmail.com,Michigan City,IN,US,Meep,Newton,,,,
+Frisk Dreamurr,,,Youth,9/13/2016 4:22:14,IHaveALotOfParents@Underground.Net,The Ruins,The Surface,The Underground,Frisk,D.,,,,
+Shelby Bradbury,Supporter,9/13/2016 4:26:30,,,GracefulAce@Tailer.com,Pureshed City,Millington,England,Shaun,B.,305,,,
+Craig Xerxes Retsnimde,,,Kid-in-tow,9/14/2016 3:20:55,YaBoy@Deeznuts.org,Jerville,Smufton-on-the-barrows,Elgarn,Huilky,Jervsondottirson,306,,,
+Derf Relmits,,,First Worldcon,9/16/2016 4:14:11,fiddle-dee-dee@tara.manse,Atlantis,Santorini,Crete,Wheres,Waldo,307,,,
+Fizzgig von Fuzzelbutt,,,Adult,9/25/2016 2:21:16,Noone@loopback.edu,Rlyeh,Botali,Hell,Fizzgig,Von Fuzzelbutt,308,,,
+Marimekko Mirjala,,,Youth,9/25/2016 17:51:51,marimiri@meks.fi,Urjakkala,Millinen,Magalo,,,,,,
+Fairy Land,,,First Worldcon,9/26/2016 19:04:13,fl@unseeliecourt.org,,,underground probably,,,309,,,
+Fizzleborg Humperding,,,Kid-in-tow,10/6/2016 22:56:11,hump@ding.lol,Krachmannlachens,Hinterdingen - Legenscheid,Banalachen,,,310,,,
+Falkrunn Ungart,,,Kid-in-tow,1/17/2017 10:18:26,intricatemasonryyay@ymail.com,Waren,Kein,Denmark,Falkrunn,Ungart,,,,

--- a/tools/kansa-importer/index.js
+++ b/tools/kansa-importer/index.js
@@ -152,6 +152,7 @@ function personData(rec) {
     'public_first_name', 'public_last_name',
     'email',
     'city', 'state', 'country',
+    'postcode', 'address',
     'badge_text'
   ].reduce((data, key) => {
     const v = rec[key];


### PR DESCRIPTION
* [x] added `postcode`, `address`, and `badge_text` support to most kansa api places already catering `country`
* [x] some lint fix missing semicolon insertions