### PR TITLE
i6 - change emails to have a single link to nominations landing page

### DIFF
--- a/config/message-templates/hugo-update-email.mustache
+++ b/config/message-templates/hugo-update-email.mustache
@@ -9,11 +9,11 @@ The email address attached to this Worldcon membership has been updated. Please 
 
 If you have any questions regarding the membership update, please contact registration@dublin2019.com.
 
+To nominate for the 2019 Hugo Awards and 1943 Retro Hugo Awards:
 
-To nominate for the 2019 Hugo Awards: {{&login_uri}}/nominate
-To nominate for the 1943 Retro Hugo Awards: {{&login_uri}}/nominate-retro
+{{&login_uri}}/nominate-landing
 
-These links are personal to you, so it should not be shared.
+This link is personal to you, so it should not be shared.
 
 If you have difficulties accessing the membership site, or you have more general questions, you can e-mail registration@dublin2019.com for assistance.
 

--- a/config/message-templates/hugo-update-email.mustache
+++ b/config/message-templates/hugo-update-email.mustache
@@ -9,7 +9,7 @@ The email address attached to this Worldcon membership has been updated. Please 
 
 If you have any questions regarding the membership update, please contact registration@dublin2019.com.
 
-To nominate for the 2019 Hugo Awards and 1943 Retro Hugo Awards:
+To nominate for the 2019 Hugo Awards and 1944 Retro Hugo Awards:
 
 {{&login_uri}}/nominate-landing
 

--- a/config/message-templates/hugo-update-nominations.mustache
+++ b/config/message-templates/hugo-update-nominations.mustache
@@ -15,7 +15,7 @@ Below is a summary of your current nominating ballot:
 
 You may make changes to your nominations until 15 March 2019 at 11:59pm Pacific Daylight Time (2:59am Eastern Daylight Time, 06:59am Greenwich Mean Time, both on 16 March), by using the following link to sign in again:
 
-To nominate for the 2019 Hugo Awards and 1943 Retro Hugo Awards:
+To nominate for the 2019 Hugo Awards and 1944 Retro Hugo Awards:
 
 {{&login_uri}}/nominate-landing
 

--- a/config/message-templates/hugo-update-nominations.mustache
+++ b/config/message-templates/hugo-update-nominations.mustache
@@ -7,16 +7,17 @@ Dear {{&name}},
 
 Thank you for your nomination for the 2019 Hugo Awards, John W. Campbell Award and 1944 Retro Hugo Awards.
 
-We know that some voters have experienced problems when trying to change their nominations. If this happens to you, please use the links below to get to your ballot; then click on the top left menu, click on "My Memberships", and then click on the "Nominate" button to get back to the ballot. You should be able to change and delete as desired.
+We know that some voters have experienced problems when trying to change their nominations, which is caused by the page being loaded while the system is logging you in. To prevent this, the nominations link now takes you to a landing page from which you can navigate to both the 2019 Hugos and 1944 Retro Hugos pages, which ensures that you will have been fully logged in when you open those pages.
 
 Below is a summary of your current nominating ballot:
 
 {{&nominations}}
 
-You may make changes to your nominations until 15 March 2019 at 11:59pm Pacific Daylight Time (2:59am Eastern Daylight Time, 06:59am Greenwich Mean Time, both on 16 March), by using the following links to sign in again:
+You may make changes to your nominations until 15 March 2019 at 11:59pm Pacific Daylight Time (2:59am Eastern Daylight Time, 06:59am Greenwich Mean Time, both on 16 March), by using the following link to sign in again:
 
-To nominate for the 2019 Hugo Awards: {{&login_uri}}/nominate
-To nominate for the 1944 Retro Hugo Awards: {{&login_uri}}/nominate-retro
+To nominate for the 2019 Hugo Awards and 1943 Retro Hugo Awards:
+
+{{&login_uri}}/nominate-landing
 
 
 Dublin 2019 - An Irish Worldcon


### PR DESCRIPTION
I've changed the two existing emails to only have the single link to the Hugo Nominations landing page. We may want to do more work, if we're sending out a one-off email to let people know.

This pull request fixes #6 .